### PR TITLE
Correctly kills all spawned child process

### DIFF
--- a/kill.js
+++ b/kill.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const psTree = require('ps-tree');
+const spawn = require('cross-spawn');
+const {
+  exec
+} = require('child_process');
+let defaultSignal = 'SIGUSR2';
+let hasPS = true;
+
+const isWindows = process.platform === 'win32';
+
+// discover if the OS has `ps`, and therefore can use psTree
+exec('ps', function (error) {
+  if (error) {
+    hasPS = false;
+  }
+});
+
+module.exports = (child, signal) => {
+  signal = signal || defaultSignal;
+
+  return new Promise((resolve, reject) => {
+    if (isWindows) {
+      exec('taskkill /pid ' + child.pid + ' /T /F');
+      resolve();
+    } else {
+      if (hasPS) {
+        psTree(child.pid, function (err, kids) {
+          spawn('kill', ['-s', signal, child.pid].concat(kids.map(function (p) {
+            return p.PID;
+          }))).on('close', resolve);
+        });
+      } else {
+        exec('kill -s ' + signal + ' ' + child.pid, function () {
+          // ignore if the process has been killed already
+          resolve();
+        });
+      }
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "cross-spawn": "^5.1.0",
+    "ps-tree": "^1.1.0",
     "typescript": "*"
   }
 }


### PR DESCRIPTION
Fixes an issue with hanging child process that are spawned from onSuccess command.
The same issue was fixed in nodemon repo: https://github.com/remy/nodemon/issues/760
Same fix applied in this PR.

Code is mostly copied from: https://github.com/remy/nodemon/blob/master/lib/monitor/run.js

In general, the solution is to get all spawned child processes from a specified PID by using `ps-tree` package and than kill each process individually.

This fix works for my test case where I run tsc-watch with node debugger like:
`tsc-watch --onSuccess "node --debug=5858 dist/index.js"`

Before this fix I was getting an error on node restart:
`Error: listen EADDRINUSE :::5858`