### PR TITLE
Fix default color

### DIFF
--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -33,7 +33,7 @@ function color(line) {
     return chalk.green(line);
   }
 
-  return chalk.white(line);
+  return line;
 }
 
 function print(lines) {
@@ -62,7 +62,7 @@ function getCommandIdx(inputArgs, command) {
 function runCommand(fullCommand) {
   if (fullCommand) {
     const parts = fullCommand.split(' ').filter(a => a.length > 0);
-    return spawn(parts[0], parts.slice(1), {stdio: 'inherit'})
+    return spawn(parts[0], parts.slice(1), { stdio: 'inherit' })
   }
 }
 
@@ -153,7 +153,7 @@ tscProcess.stdout.on('data', buffer => {
             failureProcess.on('exit', code => {
               resolve(code);
             });
-          });  
+          });
         }
       });
     } else {
@@ -181,7 +181,7 @@ tscProcess.stdout.on('data', buffer => {
 });
 
 const Signal = {
-  send: typeof process.send === 'function' ? (...e) => process.send(...e) : () => {},
+  send: typeof process.send === 'function' ? (...e) => process.send(...e) : () => { },
   _successStr: 'first_success',
   emitSuccess: () => {
     Signal.send(Signal._successStr);


### PR DESCRIPTION
This is a very simple fix for #15. It just outputs the text without adding any special color in the default case.