### PR TITLE
Add --originalStdout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - `--onFirstSuccess COMMAND` - The `COMMAND` will be executed only one time, on the first successful TypeScript compilation.
 - `--onFailure COMMAND` - The `COMMAND` will be executed on failed TypeScript compilation.
 - `--noColors` - `tsc-watch` colors the output with green on success, and in red on failiure. Add this argument to prevent that.
+- `--originalStdout` - `tsc-watch` does not alter the output of the compiler at all. (Use typescript's `--pretty` option to force color output.)
 
 ## Install
 

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -52,6 +52,7 @@ function processArgs(inputArgs) {
     .filter(arg => arg.toLowerCase() !== '-w')
     .filter(arg => arg.toLowerCase() !== '--watch')
     .filter(arg => arg.toLowerCase() !== '--nocolors')
+    .filter(arg => arg.toLowerCase() !== '--originalstdout')
     .filter(arg => arg.toLowerCase() !== '--onsuccess')
     .filter(arg => arg.toLowerCase() !== '--onfailure')
     .filter(arg => arg.toLowerCase() !== '--onfirstsuccess');
@@ -114,6 +115,7 @@ const onFirstSuccessCommand = getCustomeCommand('--onFirstSuccess');
 const onSuccessCommand = getCustomeCommand('--onSuccess');
 const onFailureCommand = getCustomeCommand('--onFailure');
 const noColors = getCommandIdx(process.argv, '--noColors') > -1;
+const originalStdout = getCommandIdx(process.argv, '--originalStdout') > -1;
 
 const args = processArgs(process.argv);
 
@@ -126,7 +128,9 @@ tscProcess.stdout.on('data', buffer => {
     .filter(a => a.length > 0)
     .map(a => a.replace(typescriptWatchCommandRegex, newAdditionToSyntax));
 
-  print(lines);
+  if (!originalStdout) print(lines);
+  else process.stdout.write(buffer);
+
   const cleanLines = removeColors(lines);
   const newCompilation = cleanLines.some(line => compilationStartedRegex.test(line));
   if (newCompilation) {


### PR DESCRIPTION
This option lets the tsc-watch programm directly pipe the output of `tsc --watch` to `stdout`, without altering it. I use this to get `tsc`'s colors to the terminal (with the `--pretty` option, to force it to output colors).