### PR TITLE
Fix `client.kill()`, and tsc-watch SIGTERM handling

### DIFF
--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -3,8 +3,9 @@
 'use strict';
 
 const chalk = require('chalk');
-const spawn = require('cross-spawn');
 const killer = require('./killer');
+const nodeCleanup = require('node-cleanup');
+const spawn = require('cross-spawn');
 const stripAnsi = require('strip-ansi');
 
 const compilationStartedRegex = /Starting incremental compilation/;
@@ -191,5 +192,7 @@ const Signal = {
   emitFail: () => Signal.send('compile_errors')
 };
 
-tscProcess.on('exit', () => killAllProcesses());
-process.on('SIGTERM', () => tscProcess.kill(0));
+nodeCleanup((_exitCode, signal) => {
+  killAllProcesses();
+  tscProcess.kill(signal);
+});

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chalk": "^2.3.0",
     "cross-spawn": "^5.1.0",
     "ps-tree": "^1.1.0",
+    "node-cleanup": "^2.1.2",
     "strip-ansi": "^4.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi team,

When using the tsc-watch client, I noticed that `client.kill()` doesn't actually kill tsc-watch or `tsc`. When my parent process exits, `pstree` shows them hanging around as orphans until I directly kill them. ([client.js](https://github.com/gilamran/tsc-watch/blob/master/lib/client.js#L12) uses `childProcess.kill()`, which sends a `SIGTERM`).

You can reproduce this problem on any project that uses the most recent version of tsc-watch:

```bash
# --preserveWatchOutput so the pid output hangs around
$ tsc-watch --preserveWatchOutput &
[2] 66473
...

$ kill -s SIGTERM 66473

# still shows `tsc-watch` and its child `tsc`
$ pstree | grep -A1 66473

```
It looks like this problem was partially introduced by #23. Prior to that change, SIGTERM would kill the `tsc-watch` process, but not the `tsc` process. With that change, neither process would exit from a SIGTERM. This was due to a combination of two issues introduced by #23:
1. When you override the `process.on('SIGTERM', ..)` handler, it becomes your responsibility to kill your process. This is why `tsc-watch` doesn't exit on SIGTERM today.
2. `tscProcess.kill(0)` doesn't cause the `tsc` process to exit. [`0` is special-cased](https://nodejs.org/api/process.html#process_process_kill_pid_signal) in nodejs to "test for the existence of a process", and doesn't actually kill it. This is why `tsc` doesn't exist on SIGTERM today.

It seems like exit cleanup is tricky here, so I recommend using [node-cleanup](https://www.npmjs.com/package/node-cleanup), which specializes in understanding how to handle various exit scenarios.


`node-cleanup` doesn't add any other new dependencies:
```
$ npm ls
...
├── mocha-eventually@1.1.0
├── node-cleanup@2.1.2
├─┬ ps-tree@1.1.0m@3.3.4
...
```