### PR TITLE
Fixes tsc desire for `--build` or `b` to be first option

### DIFF
--- a/lib/args-manager.js
+++ b/lib/args-manager.js
@@ -17,7 +17,7 @@ function hasWatchCommand(args) {
 
 function forceWatch(args) {
   if (!hasWatchCommand(args)) {
-    args.unshift('--watch');
+    args.push('--watch');
   }
 
   return args;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsc-watch",
-  "version": "1.1.35",
+  "version": "1.0.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsc-watch",
-  "version": "1.0.31",
+  "version": "1.1.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/args-manager.it.js
+++ b/test/args-manager.it.js
@@ -4,17 +4,23 @@ const { extractArgs, isCommandExist, hasWatchCommand } = require('../lib/args-ma
 describe('Args Manager', () => {
   it('Should remove the runner args', () => {
     const { args } = extractArgs(['node', 'tsc-watch.js', '-d', '1.ts']);
-    expect(args).to.deep.eq(['--watch', '-d', '1.ts']);
+    expect(args).to.deep.eq(['-d', '1.ts', '--watch']);
   });
 
   it('Should remove custom args', () => {
     const { args } = extractArgs(['node', 'tsc-watch.js', '--compiler', 'MY_COMPILER', '--nocolors', '--noclear', '--onsuccess', 'MY_SUCCESS', '--onfailure', 'MY_FAILURE', '--onfirstsuccess', 'MY_FIRST', '-d', '1.ts']);
-    expect(args).to.deep.eq(['--watch', '-d', '1.ts']);
+    expect(args).to.deep.eq(['-d', '1.ts', '--watch']);
   });
 
   it('Should force watch', () => {
     const { args } = extractArgs(['node', 'tsc-watch.js', '1.ts']);
     expect(args.indexOf('--watch')).to.be.greaterThan(-1);
+  });
+
+  it('Should not change the argv order options if watch was not specified (fixes --build option)', () => {
+    const { args } = extractArgs(['node', 'tsc-watch.js', '--build', '1.tsconfig.conf', '2.tsconfig.conf']);
+    expect(args.indexOf('--build')).to.be.equal(0);
+    expect(args.indexOf('--watch')).to.be.equal(3);
   });
 
   it('Should not re-add watch', () => {


### PR DESCRIPTION
makes sure if `-w` or `--watch` options was not added by the user the forced watch will not add it at the begging of the arguments (breaking some weird desire for tsc to have the `-b` or `--build` option as first argument) 