### PR TITLE
Force kill child process, when windows.

### DIFF
--- a/lib/killer.js
+++ b/lib/killer.js
@@ -17,7 +17,7 @@ exec('ps', function(error) {
 module.exports = function kill(child) {
   return new Promise(resolve => {
     if (isWindows) {
-      exec('taskkill /pid ' + child.pid + ' /T', () => resolve());
+      exec('taskkill /pid ' + child.pid + ' /T /F', () => resolve());
     } else {
       if (hasPS) {
         psTree(child.pid, function(err, kids) {


### PR DESCRIPTION
Add /F option for forcefully terminate windows process.

![2019-05-19](https://user-images.githubusercontent.com/14291129/57973597-4c3cc200-79e6-11e9-8e1b-1aefec6d3b0f.png)


[Nodemon](https://github.com/remy/nodemon/blob/20ccb623c4/lib/monitor/run.js#L334) already using this.
