### PR TITLE
Add support for TypeScript 2.7.2 when parsing the output from tsc

### DIFF
--- a/lib/stdout-manipulator.js
+++ b/lib/stdout-manipulator.js
@@ -6,8 +6,8 @@ const typescriptErrorRegex = /\(\d+,\d+\): error TS\d+: /;
 
 const compilationCompleteWithErrorRegex = / Found [^0][0-9]* error[s]?\. Watching for file changes\./;
 const compilationCompleteWithoutErrorRegex = / Found 0 errors\. Watching for file changes\./;
-const compilationCompleteRegex = / Found \d+ error[s]?\. Watching for file changes\./;
-const newCompilationRegex = / File change detected\. Starting incremental compilation\.\.\./;
+const compilationCompleteRegex = /( Compilation complete\. Watching for file changes\.| Found \d+ error[s]?\. Watching for file changes\.)/;
+const newCompilationRegex = /( Starting compilation in watch mode\.\.\.| File change detected\. Starting incremental compilation\.\.\.)/;
 
 const newAdditionToSyntax = [
   ' -w, --watch                                        Watch input files. [always on]',
@@ -64,10 +64,17 @@ function manipulate(buffer) {
 
 function detectState(lines) {
   const clearLines = removeColors(lines);
-  const compilationError = clearLines.some(line => compilationCompleteWithErrorRegex.test(line));
+  const newCompilation = clearLines.some(line => newCompilationRegex.test(line));
+  const compilationError = clearLines.some(
+    line =>
+      compilationCompleteWithErrorRegex.test(line) ||
+      typescriptErrorRegex.test(line) ||
+      typescriptPrettyErrorRegex.test(line)
+  );
   const compilationComplete = clearLines.some(line => compilationCompleteRegex.test(line));
 
   return {
+    newCompilation: newCompilation,
     compilationError: compilationError,
     compilationComplete: compilationComplete,
   };

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -41,6 +41,7 @@ try {
   throw e;
 }
 
+let compilationErrorSinceStart = false;
 const tscProcess = spawn(bin, [...args]);
 tscProcess.stdout.on('data', buffer => {
   if (noClear && isClear(buffer)) {
@@ -50,12 +51,15 @@ tscProcess.stdout.on('data', buffer => {
   const lines = manipulate(buffer);
   print(noColors, noClear, lines);
   const state = detectState(lines);
+  const newCompilation = state.newCompilation;
   const compilationError = state.compilationError;
   const compilationComplete = state.compilationComplete;
 
+  compilationErrorSinceStart = (!newCompilation && compilationErrorSinceStart) || compilationError;
+
   if (compilationComplete) {
     killProcesses(false).then(() => {
-      if (compilationError) {
+      if (compilationErrorSinceStart) {
         Signal.emitFail();
         if (onFailureCommand) {
           failureKiller = run(onFailureCommand);


### PR DESCRIPTION
This change supports older version of the TypeScript compiler as they have a different output when in watch mode. In version 2.7.2, the compiler always writes `Compilation complete. Watching for file changes.` even though there are errors. So one needs to keep track of the errors as they occur.