### PR TITLE
Add support for running unit tests against multiple versions of tsc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 npm-debug.log
 tmp/
+test/tsc-list/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsc-watch",
-  "version": "2.2.2",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1064,9 +1064,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
-      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The TypeScript compiler with onSuccess command",
   "scripts": {
     "publish": "node release.js",
-    "test": "mocha test/**/*.js"
+    "test": "mocha \"test/{,!(tsc-list)/**/}*.js\""
   },
   "bin": {
     "tsc-watch": "./index.js"

--- a/test/client.it.js
+++ b/test/client.it.js
@@ -4,38 +4,65 @@ const mochaEventually = require('mocha-eventually');
 const eventually = fn => mochaEventually(fn, 8000, 50);
 const TscWatchClient = require('../lib/client');
 const { driver: tscWatchDriver } = require('./driver.js');
+const { tscInstaller } = require('./tsc-installer');
 
 describe('Client Events', () => {
-  let watchClient;
-  let callback;
+  for (const tsc of tscInstaller.supportedCompilers()) {
+    describe('TSC ' + tsc.version, () => {
+      const testSuffix = ' (tsc ' + tsc.version + ')';
+      let watchClient;
+      let callback;
 
-  beforeEach(() => {
-    watchClient = new TscWatchClient();
-    callback = sinon.stub();
-  });
-  afterEach(() => watchClient.kill());
+      beforeEach(() => {
+        watchClient = new TscWatchClient();
+        callback = sinon.stub();
+      });
+      afterEach(() => watchClient.kill());
 
-  describe('Events', () => {
-    it('Should emit "first_success" on first success', () => {
-      watchClient.on('first_success', callback);
-      watchClient.start('--noClear', '--out', './tmp/output.js', './tmp/fixtures/passing.ts');
+      describe('Events' + testSuffix, () => {
+        it('Should emit "first_success" on first success' + testSuffix, () => {
+          watchClient.on('first_success', callback);
+          watchClient.start(
+            '--noClear',
+            '--compiler',
+            tsc.path,
+            '--out',
+            './tmp/output.js',
+            './tmp/fixtures/passing.ts'
+          );
 
-      return eventually(() => expect(callback.calledOnce).to.be.true);
+          return eventually(() => expect(callback.calledOnce).to.be.true);
+        });
+
+        it('Should fire "subsequent_success" on subsequent successes' + testSuffix, () => {
+          watchClient.on('subsequent_success', callback);
+          watchClient.start(
+            '--noClear',
+            '--compiler',
+            tsc.path,
+            '--out',
+            './tmp/output.js',
+            './tmp/fixtures/passing.ts'
+          );
+          tscWatchDriver.modifyAndSucceedAfter(1500);
+
+          return eventually(() => expect(callback.calledOnce).to.be.true);
+        });
+
+        it('Should fire "compile_errors" on when tsc compile errors occur' + testSuffix, () => {
+          watchClient.on('compile_errors', callback);
+          watchClient.start(
+            '--noClear',
+            '--compiler',
+            tsc.path,
+            '--out',
+            './tmp/output.js',
+            './tmp/fixtures/failing.ts'
+          );
+
+          return eventually(() => expect(callback.calledOnce).to.be.true);
+        });
+      });
     });
-
-    it('Should fire "subsequent_success" on subsequent successes', () => {
-      watchClient.on('subsequent_success', callback);
-      watchClient.start('--noClear', '--out', './tmp/output.js', './tmp/fixtures/passing.ts');
-      tscWatchDriver.modifyAndSucceedAfter(1500);
-
-      return eventually(() => expect(callback.calledOnce).to.be.true);
-    });
-
-    it('Should fire "compile_errors" on when tsc compile errors occur', () => {
-      watchClient.on('compile_errors', callback);
-      watchClient.start('--noClear', '--out', './tmp/output.js', './tmp/fixtures/failing.ts');
-
-      return eventually(() => expect(callback.calledOnce).to.be.true);
-    });
-  });
+  }
 });

--- a/test/driver.js
+++ b/test/driver.js
@@ -15,8 +15,15 @@ class Driver {
     return this;
   }
 
-  startWatch({ failFirst, pretty } = {}) {
-    const params = ['--noClear', '--out', './tmp/output.js', failFirst ? FAIL_FILE_PATH : SUCCESS_FILE_PATH];
+  startWatch({ failFirst, pretty, compiler } = {}) {
+    const params = [
+      '--noClear',
+      '--out',
+      './tmp/output.js',
+      failFirst ? FAIL_FILE_PATH : SUCCESS_FILE_PATH,
+      '--compiler',
+      compiler
+    ];
     if (pretty) {
       params.push('--pretty');
     }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---timeout 6000
+--timeout 10000

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -1,0 +1,3 @@
+const { tscInstaller } = require('./tsc-installer');
+
+tscInstaller.init(['2.7.2', '3.3.3', 'next']);

--- a/test/tsc-installer.js
+++ b/test/tsc-installer.js
@@ -1,0 +1,49 @@
+const { execSync } = require('child_process');
+const { join } = require('path');
+const { existsSync, mkdirSync, chmodSync } = require('fs');
+
+const tscListDir = join(__dirname, 'tsc-list/');
+
+class TscInstaller {
+  constructor() {
+    this._supportedVersions = [];
+  }
+
+  init(supportedVersions) {
+    this._supportedVersions = supportedVersions || [];
+
+    console.log('Installing different versions of TSC ...');
+
+    for (const tscVersion of this._supportedVersions) {
+      console.log('Installing TSC ' + tscVersion);
+      this._install(tscVersion);
+    }
+  }
+
+  supportedCompilers() {
+    return this._supportedVersions.map(version => ({
+      version: version,
+      path: this._compilerPath(version),
+    }));
+  }
+
+  _compilerPath(version) {
+    return join(tscListDir, version + '/node_modules/typescript/bin/tsc');
+  }
+
+  _install(version) {
+    if (!existsSync(tscListDir)) {
+      mkdirSync(tscListDir);
+    }
+
+    const tscInstallationDir = join(tscListDir, version);
+    if (!existsSync(tscInstallationDir)) {
+      mkdirSync(tscInstallationDir);
+      execSync('npm init -y', { cwd: tscInstallationDir });
+    }
+
+    execSync('npm i typescript@' + version + ' --no-save --silent', { cwd: tscInstallationDir });
+  }
+}
+
+module.exports.tscInstaller = new TscInstaller();

--- a/test/tsc-watch.it.js
+++ b/test/tsc-watch.it.js
@@ -2,41 +2,58 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const mochaEventually = require('mocha-eventually');
 const { driver } = require('./driver');
+const { tscInstaller } = require('./tsc-installer');
 
 const eventually = fn => mochaEventually(fn, 8000, 10);
 
 describe('TSC-Watch child process messages', () => {
-  beforeEach(() => (this.listener = sinon.stub()));
-  afterEach(() => driver.reset());
+  for (const tsc of tscInstaller.supportedCompilers()) {
+    describe('TSC ' + tsc.version, () => {
+      const testSuffix = ' (tsc ' + tsc.version + ')';
 
-  it('Should send "first_success" on first success', () => {
-    driver.subscribe('first_success', this.listener).startWatch();
+      beforeEach(() => {
+        this.listener = sinon.stub();
+      });
+      afterEach(() => driver.reset());
 
-    return eventually(() => expect(this.listener.callCount).to.be.equal(1));
-  });
+      it('Should send "first_success" on first success' + testSuffix, () => {
+        driver
+          .subscribe('first_success', this.listener)
+          .startWatch({ compiler: tsc.path });
 
-  it('Should send "subsequent_success" on subsequent successes', () => {
-    driver
-      .subscribe('subsequent_success', this.listener)
-      .startWatch()
-      .modifyAndSucceedAfter(1000)
-      .modifyAndSucceedAfter(3000);
+        return eventually(() => expect(this.listener.callCount).to.be.equal(1));
+      });
 
-    return eventually(() => expect(this.listener.callCount).to.be.equal(2));
-  });
+      it('Should send "subsequent_success" on subsequent successes' + testSuffix, () => {
+        driver
+          .subscribe('subsequent_success', this.listener)
+          .startWatch({ compiler: tsc.path })
+          .modifyAndSucceedAfter(1000)
+          .modifyAndSucceedAfter(3000);
 
-  it('Should send "compile_errors" when tsc compile errors occur', () => {
-    driver
-      .subscribe('compile_errors', this.listener)
-      .startWatch({ failFirst: true })
-      .modifyAndFailAfter(1500);
+        return eventually(() => expect(this.listener.callCount).to.be.equal(2));
+      });
 
-    return eventually(() => expect(this.listener.callCount).to.be.equal(2));
-  });
+      it('Should send "compile_errors" when tsc compile errors occur' + testSuffix, () => {
+        driver
+          .subscribe('compile_errors', this.listener)
+          .startWatch({ failFirst: true, compiler: tsc.path })
+          .modifyAndFailAfter(1500);
 
-  it('Should send "compile_errors" when pretty param was set', () => {
-    driver.subscribe('compile_errors', this.listener).startWatch({ failFirst: true, pretty: true });
+        return eventually(() => expect(this.listener.callCount).to.be.equal(2));
+      });
 
-    return eventually(() => expect(this.listener.callCount).to.be.equal(1));
-  });
+      it('Should send "compile_errors" when pretty param was set' + testSuffix, () => {
+        driver
+          .subscribe('compile_errors', this.listener)
+          .startWatch({
+            failFirst: true,
+            pretty: true,
+            compiler: tsc.path
+          });
+
+        return eventually(() => expect(this.listener.callCount).to.be.equal(1));
+      });
+    });
+  }
 });


### PR DESCRIPTION
I have added a helper class `TscInstaller` to install, using npm, different versions of TypeScript and run the unit tests against each version of the compiler.