### PR TITLE
tsc-watch: call `onSuccessCommand` alongside `onFirstSuccessCommand`

### DIFF
--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -69,7 +69,8 @@ tscProcess.stdout.on('data', buffer => {
         if (firstTime && onFirstSuccessCommand) {
           firstTime = false;
           firstSuccessKiller = run(onFirstSuccessCommand);
-        } else if (onSuccessCommand) {
+        }
+        if (onSuccessCommand) {
           successKiller = run(onSuccessCommand);
         }
       }


### PR DESCRIPTION
I suggest to adjust behavior for `onSuccess` parameter, which in one case is not called after the first success, contrary to the name. Silly thing is that `onSuccess` is called after the first success when we do not add `onFirstSuccess` argument, so adding second flag changes behavior of the first one.
As we have two success actions: `onFirstSuccess` and `onSuccess`, we may later introduce `onSubsequentSuccess` but `onSuccess` is definitely missing its goal right now.

My common use case is like this:
 - `onFirstSuccess` triggers webpack client bundling
 - `onSuccess` triggers Node server
When `onSuccess` triggers only after the second success I won't have Node server running, on the other hand when I put server trigger in `onFirstSuccess` I won't be able to restart it in `onSuccess` because `onFirstSuccess` is not killed (which is fine for webpack bundle, but what about server).
