### PR TITLE
Change kill signal and add unit test

### DIFF
--- a/lib/killer.js
+++ b/lib/killer.js
@@ -2,7 +2,7 @@ const psTree = require('ps-tree');
 const spawn = require('cross-spawn');
 const { exec } = require('child_process');
 
-let KILL_SIGNAL = '15'; // SIGTERM
+let KILL_SIGNAL = '-15'; // SIGTERM
 let hasPS = true;
 
 const isWindows = process.platform === 'win32';
@@ -21,10 +21,10 @@ module.exports = function kill(child) {
     } else {
       if (hasPS) {
         psTree(child.pid, function(err, kids) {
-          spawn('kill', ['-s', KILL_SIGNAL, child.pid].concat( kids.map(p => p.PID) )).on('close', resolve);
+          spawn('kill', [KILL_SIGNAL, child.pid].concat( kids.map(p => p.PID) )).on('close', resolve);
         });
       } else {
-        exec('kill -s ' + KILL_SIGNAL + ' ' + child.pid, resolve);
+        exec('kill ' + KILL_SIGNAL + ' ' + child.pid, resolve);
       }
     }
   });

--- a/lib/killer.js
+++ b/lib/killer.js
@@ -2,7 +2,7 @@ const psTree = require('ps-tree');
 const spawn = require('cross-spawn');
 const { exec } = require('child_process');
 
-let KILL_SIGNAL = '-15'; // SIGTERM
+let KILL_SIGNAL = '15'; // SIGTERM
 let hasPS = true;
 
 const isWindows = process.platform === 'win32';
@@ -21,10 +21,10 @@ module.exports = function kill(child) {
     } else {
       if (hasPS) {
         psTree(child.pid, function(err, kids) {
-          spawn('kill', [KILL_SIGNAL, child.pid].concat( kids.map(p => p.PID) )).on('close', resolve);
+          spawn('kill', ['-' + KILL_SIGNAL, child.pid].concat( kids.map(p => p.PID) )).on('close', resolve);
         });
       } else {
-        exec('kill ' + KILL_SIGNAL + ' ' + child.pid, resolve);
+        exec('kill -' + KILL_SIGNAL + ' ' + child.pid, resolve);
       }
     }
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsc-watch",
-  "version": "4.2.4",
+  "version": "4.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsc-watch",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "description": "The TypeScript compiler with onSuccess command",
   "scripts": {
     "test": "mocha test/**/*.js"

--- a/test/client.it.js
+++ b/test/client.it.js
@@ -3,7 +3,6 @@ const sinon = require('sinon');
 const mochaEventually = require('mocha-eventually');
 const eventually = fn => mochaEventually(fn, 8000, 50);
 const TscWatchClient = require('../lib/client');
-const { driver: tscWatchDriver } = require('./driver.js');
 
 describe('Client Events', () => {
   let watchClient;

--- a/test/runner.it.js
+++ b/test/runner.it.js
@@ -1,0 +1,23 @@
+const { expect } = require('chai');
+const runner = require('../lib/runner');
+
+describe.only('Runner', () => {
+  it('Should start a long running process and kill it before it finishes', (done) => {
+    const kill = runner('sleep 10')
+    setTimeout(function() {
+      kill().then(function(result) {
+        expect(result).to.deep.equal([0,null])
+        done()
+      })
+    }, 1)
+  })
+  it('Should start a short running process and not kill it before it finishes', (done) => {
+    const kill = runner('echo')
+    setTimeout(function() {
+      kill().then(function(result) {
+        expect(result).to.deep.equal([1,0])
+        done()
+      })
+    }, 5)
+  })
+})


### PR DESCRIPTION
I noticed that my package.json scripts weren't being killed after the update to version 2.4.6. If I read the documentation correctly (https://pubs.opengroup.org/onlinepubs/9699919799/utilities/kill.html) the actual kill command should be `kill -15`.

This PR contains that update as well as a unit test to hopefully check the positive and negative case.