### PR TITLE
fix: spawn compiler using node

### DIFF
--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -46,7 +46,7 @@ try {
 }
 
 let compilationErrorSinceStart = false;
-const tscProcess = spawn(bin, [...args]);
+const tscProcess = spawn('node', [bin, ...args]);
 const rl = readline.createInterface({
   input: tscProcess.stdout,
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

`tsc-watch` tries to spawn the TypeScript compiler by passing the path to the javascript file directly to `cross-spawn`. This doesn't work under Yarn PnP where the file is within a zip archive, so we need to explicitly tell `cross-spawn` to spawn it using node.

Fixes https://github.com/gilamran/tsc-watch/issues/79

**How did you fix it?**

Spawn the typescript compiler using node