### PR TITLE
fix: resolve compiler flag from cwd

### DIFF
--- a/lib/args-manager.js
+++ b/lib/args-manager.js
@@ -54,6 +54,8 @@ function extractArgs(args) {
   let compiler = extractCommandWithValue(allArgs, '--compiler');
   if (!compiler) {
     compiler = 'typescript/bin/tsc';
+  } else {
+    compiler = require.resolve(compiler, { paths: [process.cwd()] });
   }
 
   return {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`tsc-watch` tries to resolve the compiler provided in the `--compiler` flag from itself instead of the context that provides it.
https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies

Fixes https://github.com/gilamran/tsc-watch/issues/110

**How did you fix it?**

Resolve the `--compiler` flag from the cwd