### PR TITLE
Add onCompilationStarted option, enable  and fix all unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 npm-debug.log
 tmp/
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,75 +1,82 @@
 # @gilamran/tsc-watch CHANGELOG
 
+## v4.4.1 - 17/8/2021
+
+- Added `onCompilationStarted` option - (Thanks to @axtk for the idea and @dko-slapdash for the PR)
+- Fix: enable unit tests which were turned off accidentally
+
 ## v4.4.0 - 26/5/ 2021
-tsc-watch is now listenning to message and reacts to them.
+
+- tsc-watch is now listening to message and reacts to them
+
 ## v4.3.1 - 26/5/2021
 
-fix: compiler resolving  - (Thanks to @merceyz for the PR)
+- Fix: compiler resolving  - (Thanks to @merceyz for the PR)
 
 ## v4.2.9 - 23/6/2020
 
-fix: upgrade cross-spawn and strip-ansi (node 8+)  - (Thanks to @FauxFaux for the PR)
+- Fix: upgrade cross-spawn and strip-ansi (node 8+)  - (Thanks to @FauxFaux for the PR)
 
 ## v4.2.8 - 23/5/2020
 
-Fix: spawn compiler using node, this fixes issues with yarn v2 (pnp) - (Thanks to @merceyz)
+- Fix: spawn compiler using node, this fixes issues with yarn v2 (pnp) - (Thanks to @merceyz)
 
 ## v4.2.6 - 18/5/2020
 
-Using number 15 instead of SIGTERM to support POSIX standard - (Thanks to @Asarew)
+- Using number 15 instead of SIGTERM to support POSIX standard - (Thanks to @Asarew)
 
 ## v4.2.0 - 29/2/2020
 
-Using readline instead of raw stdout buffer - (Thanks to @Janpot for the idea)
+- Using readline instead of raw stdout buffer - (Thanks to @Janpot for the idea)
 
 ## v4.1.0 - 22/1/2020
 
-Added the `onCompilationComplete` option - (Thanks to @ackvf for the idea)
+- Added the `onCompilationComplete` option - (Thanks to @ackvf for the idea)
 
 ## v4.0.0 - 19/9/2019
 
-Terminating previous processes is now done with `SIGTERM` instead of `SIGUSR2`. - (Thanks to @zontarian)
+- Terminating previous processes is now done with `SIGTERM` instead of `SIGUSR2` - (Thanks to @zontarian)
 
 ## v3.0.0 - 9/9/2019
 
-onSuccess will run on EVERY successful compilation, also on the first success. - (Thanks to @mchl-hub for the idea)
+- onSuccess will run on EVERY successful compilation, also on the first success - (Thanks to @mchl-hub for the idea)
 
 ## v2.2.1 - 19/5/2019
 
-Force kill when on windows - (Thanks to @hwwi)
+- Force kill when on windows - (Thanks to @hwwi)
 
 ## v2.2.0 - 13/5/2019
 
-Waiting for all the child processes to showdown before closing - (Thanks to @MartinLoeper)
+- Waiting for all the child processes to showdown before closing - (Thanks to @MartinLoeper)
 
 ## v2.1.0 - 12/2/2019
 
-Exporting TscWatchClient for multiple instance of `tsc-watch` - (Thanks to @pronebird)
+- Exporting TscWatchClient for multiple instance of `tsc-watch` - (Thanks to @pronebird)
 
 ## v2.0.0 - 12/2/2019
 
-As many users requested, from now on `--onFirstSuccess` process will not get killed, only when tsc-watch is killed. (Based on @amir-arad's PR)
+- As many users requested, from now on `--onFirstSuccess` process will not get killed, only when tsc-watch is killed. (Based on @amir-arad's PR)
 This version fixes Issue #20, #21 and #50.
 
 ## v1.1.37 - 8/2/2019
 
-Fixed coloring issues
+- Fixed coloring issues
 
 ## v1.1.36 - 31/1/2019
 
-`--watch` will be added to the end of the arguments (Thanks to @barkayal)
+- `--watch` will be added to the end of the arguments (Thanks to @barkayal)
 
 ## v1.1.35 - 28/1/2019
 
-Clean code
+- Clean code
 
 ## v1.1.32 - 27/11/2018
 
-Added --noClear command to prevent clearing the screen after each compilation
+- Added --noClear command to prevent clearing the screen after each compilation
 
 ## v1.0.32 - 27/11/2018
 
-Removed chalk dependency - (Thanks to @frank-orellana)
+- Removed chalk dependency - (Thanks to @frank-orellana)
 
 ## v1.0.31 - 27/11/2018
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 | `--onSuccess COMMAND` | Executes `COMMAND` on **every successful** compilation. |
 | `--onFirstSuccess COMMAND` | Executes `COMMAND` on the **first successful** compilation. |
 | `--onFailure COMMAND` | Executes `COMMAND` on **every failed** compilation. |
+| `--onCompilationStarted COMMAND` | Executes `COMMAND` on **every compilation start** event (initial and incremental). |
 | `--onCompilationComplete COMMAND` | Executes `COMMAND` on **every successful or failed** compilation. |
 | `--noColors` | By default tsc-watch adds colors the output with green<br>on success, and in red on failure. <br>Add this argument to prevent that. |
 | `--noClear` | In watch mode the `tsc` compiler clears the screen before reporting<br>Add this argument to prevent that. |
@@ -58,6 +59,7 @@ You can see a detailed example [here](https://github.com/gilamran/tsc-watch/blob
 
 The client is implemented as an instance of `Node.JS`'s `EventEmitter`, with the following events:
 
+- `started` - Emitted upon the compilation start (initial or incremental).
 - `first_success` - Emitted upon first successful compilation.
 - `subsequent_success` - Emitted upon every subsequent successful compilation.
 - `compile_errors` - Emitted upon every failing compilation.
@@ -71,6 +73,10 @@ Example usage:
 ```javascript
 const TscWatchClient = require('tsc-watch/client');
 const watch = new TscWatchClient();
+
+watch.on('started', () => {
+  console.log('Compilation started');
+});
 
 watch.on('first_success', () => {
   console.log('First success!');

--- a/lib/args-manager.js
+++ b/lib/args-manager.js
@@ -48,6 +48,7 @@ function extractArgs(args) {
   const onFirstSuccessCommand = extractCommandWithValue(allArgs, '--onFirstSuccess');
   const onSuccessCommand = extractCommandWithValue(allArgs, '--onSuccess');
   const onFailureCommand = extractCommandWithValue(allArgs, '--onFailure');
+  const onCompilationStarted = extractCommandWithValue(allArgs, '--onCompilationStarted');
   const onCompilationComplete = extractCommandWithValue(allArgs, '--onCompilationComplete');
   const noColors = extractCommand(allArgs, '--noColors');
   const noClear = extractCommand(allArgs, '--noClear');
@@ -62,6 +63,7 @@ function extractArgs(args) {
     onFirstSuccessCommand: onFirstSuccessCommand,
     onSuccessCommand: onSuccessCommand,
     onFailureCommand: onFailureCommand,
+    onCompilationStarted: onCompilationStarted,
     onCompilationComplete: onCompilationComplete,
     noColors: noColors,
     noClear: noClear,

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,6 +14,12 @@ class TscWatchClient extends EventEmitter {
     this.removeAllListeners();
   }
 
+  runOnCompilationStartedCommand() {
+    if (this.tsc) {
+      this.tsc.send('run-on-compilation-started-command');
+    }
+  }
+
   runOnCompilationCompleteCommand() {
     if (this.tsc) {
       this.tsc.send('run-on-compilation-complete-command');

--- a/lib/stdout-manipulator.js
+++ b/lib/stdout-manipulator.js
@@ -7,13 +7,14 @@ const typescriptErrorRegex = /\(\d+,\d+\): error TS\d+: /;
 const compilationCompleteWithErrorRegex = / Found [^0][0-9]* error[s]?\. Watching for file changes\./;
 const compilationCompleteWithoutErrorRegex = / Found 0 errors\. Watching for file changes\./;
 const compilationCompleteRegex = /( Compilation complete\. Watching for file changes\.| Found \d+ error[s]?\. Watching for file changes\.)/;
-const newCompilationRegex = /( Starting compilation in watch mode\.\.\.| File change detected\. Starting incremental compilation\.\.\.)/;
+const compilationStartedRegex = /( Starting compilation in watch mode\.\.\.| File change detected\. Starting incremental compilation\.\.\.)/;
 
 const newAdditionToSyntax = [
   ' -w, --watch                                        Watch input files. [always on]',
   ' --onSuccess COMMAND                                Executes `COMMAND` on **every successful** compilation.',
   ' --onFirstSuccess COMMAND                           Executes `COMMAND` on the **first successful** compilation.',
   ' --onFailure COMMAND                                Executes `COMMAND` on **every failed** compilation.',
+  ' --onCompilationStarted COMMAND                     Executes `COMMAND` on **every compilation start** event.',
   ' --onCompilationComplete COMMAND                    Executes `COMMAND` on **every successful or failed** compilation.',
   ' --noColors                                         Removes the red/green colors from the compiler output',
   ' --noClear                                          Prevents the compiler from clearing the screen',
@@ -34,7 +35,7 @@ function color(line, noClear) {
   // usage
   line = line.replace(tscUsageSyntaxRegex, m => `\u001B[33m${m}\u001B[39m`); // Yellow
 
-  if (noClear && newCompilationRegex.test(line)) {
+  if (noClear && compilationStartedRegex.test(line)) {
     return '\n\n----------------------\n' + line;
   }
 
@@ -59,7 +60,7 @@ function manipulate(line) {
 
 function detectState(line) {
   const clearLine = stripAnsi(line);
-  const newCompilation = newCompilationRegex.test(clearLine);
+  const compilationStarted = compilationStartedRegex.test(clearLine);
   const compilationError =
     compilationCompleteWithErrorRegex.test(clearLine) ||
     typescriptErrorRegex.test(clearLine) ||
@@ -67,7 +68,7 @@ function detectState(line) {
   const compilationComplete = compilationCompleteRegex.test(clearLine);
 
   return {
-    newCompilation: newCompilation,
+    compilationStarted: compilationStarted,
     compilationError: compilationError,
     compilationComplete: compilationComplete,
   };

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -12,12 +12,14 @@ let firstTime = true;
 let firstSuccessKiller = null;
 let successKiller = null;
 let failureKiller = null;
+let compilationStartedKiller = null;
 let compilationCompleteKiller = null;
 
 const {
   onFirstSuccessCommand,
   onSuccessCommand,
   onFailureCommand,
+  onCompilationStarted,
   onCompilationComplete,
   noColors,
   noClear,
@@ -30,8 +32,15 @@ function killProcesses(killAll) {
     killAll && firstSuccessKiller ? firstSuccessKiller() : null,
     successKiller ? successKiller() : null,
     failureKiller ? failureKiller() : null,
+    compilationStartedKiller ? compilationStartedKiller() : null,
     compilationCompleteKiller ? compilationCompleteKiller() : null,
   ]);
+}
+
+function runOnCompilationStarted() {
+  if (onCompilationStarted) {
+    compilationStartedKiller = run(onCompilationStarted);
+  }
 }
 
 function runOnCompilationComplete() {
@@ -83,11 +92,18 @@ rl.on('line', function (input) {
   const line = manipulate(input);
   print(noColors, noClear, line);
   const state = detectState(line);
-  const newCompilation = state.newCompilation;
+  const compilationStarted = state.compilationStarted;
   const compilationError = state.compilationError;
   const compilationComplete = state.compilationComplete;
 
-  compilationErrorSinceStart = (!newCompilation && compilationErrorSinceStart) || compilationError;
+  compilationErrorSinceStart = (!compilationStarted && compilationErrorSinceStart) || compilationError;
+
+  if (compilationStarted) {
+    killProcesses(false).then(() => {
+      runOnCompilationStarted();
+      Signal.emitStarted();
+    });
+  }
 
   if (compilationComplete) {
     killProcesses(false).then(() => {
@@ -115,9 +131,14 @@ if (typeof process.on === 'function') {
     let promise;
     let func;
     switch (msg) {
+      case 'run-on-compilation-started-command':
+        promise = compilationStartedKiller ? compilationStartedKiller() : Promise.resolve();
+        func = runOnCompilationStarted;
+        break;
+
       case 'run-on-compilation-complete-command':
         promise = compilationCompleteKiller ? compilationCompleteKiller() : Promise.resolve();
-        func = runonCompilationComplete;
+        func = runOnCompilationComplete;
         break;
 
       case 'run-on-first-success-command':
@@ -146,7 +167,8 @@ if (typeof process.on === 'function') {
 }
 
 const Signal = {
-  send: typeof process.send === 'function' ? (...e) => process.send(...e) : () => {},
+  send: typeof process.send === 'function' ? (...e) => process.send(...e) : () => { },
+  emitStarted: () => Signal.send('started'),
   emitFirstSuccess: () => Signal.send('first_success'),
   emitSuccess: () => Signal.send('success'),
   emitFail: () => Signal.send('compile_errors'),

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "mocha test/**/*.js"
   },
   "bin": {
-    "tsc-watch": "./index.js"
+    "tsc-watch": "index.js"
   },
   "repository": {
     "type": "git",

--- a/test/args-manager.it.js
+++ b/test/args-manager.it.js
@@ -8,7 +8,7 @@ describe('Args Manager', () => {
   });
 
   it('Should remove custom args', () => {
-    const { args } = extractArgs(['node', 'tsc-watch.js', '--compiler', 'MY_COMPILER', '--nocolors', '--noclear', '--onsuccess', 'MY_SUCCESS', '--onfailure', 'MY_FAILURE', '--onfirstsuccess', 'MY_FIRST', '-d', '1.ts']);
+    const { args } = extractArgs(['node', 'tsc-watch.js', '--compiler', 'typescript/bin/tsc', '--nocolors', '--noclear', '--onsuccess', 'MY_SUCCESS', '--onfailure', 'MY_FAILURE', '--onfirstsuccess', 'MY_FIRST', '-d', '1.ts']);
     expect(args).to.deep.eq(['-d', '1.ts', '--watch']);
   });
 
@@ -44,6 +44,11 @@ describe('Args Manager', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '--onFailure', 'COMMAND_TO_RUN', '1.ts']).onFailureCommand).to.eq('COMMAND_TO_RUN');
   });
 
+  it('Should return the onCompilationStarted', () => {
+    expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).onCompilationStarted).to.eq(null);
+    expect(extractArgs(['node', 'tsc-watch.js', '--onCompilationStarted', 'COMMAND_TO_RUN', '1.ts']).onCompilationStarted).to.eq('COMMAND_TO_RUN');
+  });
+
   it('Should return the onCompilationComplete', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).onCompilationComplete).to.eq(null);
     expect(extractArgs(['node', 'tsc-watch.js', '--onCompilationComplete', 'COMMAND_TO_RUN', '1.ts']).onCompilationComplete).to.eq('COMMAND_TO_RUN');
@@ -61,6 +66,6 @@ describe('Args Manager', () => {
 
   it('Should return the compiler', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).compiler).to.eq('typescript/bin/tsc');
-    expect(extractArgs(['node', 'tsc-watch.js', '--compiler', 'MY_COMPILER', '1.ts']).compiler).to.eq('MY_COMPILER');
+    expect(extractArgs(['node', 'tsc-watch.js', '--compiler', 'typescript/lib/tsc', '1.ts']).compiler).to.eq(require.resolve('typescript/lib/tsc'));
   });
 });

--- a/test/client.it.js
+++ b/test/client.it.js
@@ -15,6 +15,13 @@ describe('Client Events', () => {
   afterEach(() => watchClient.kill());
 
   describe('Events', () => {
+    it('Should emit "started" on compilation start', () => {
+      watchClient.on('started', callback);
+      watchClient.start('--noClear', '--out', './tmp/output.js', './tmp/fixtures/failing.ts');
+
+      return eventually(() => expect(callback.calledOnce).to.be.true);
+    });
+
     it('Should emit "first_success" on first success', () => {
       watchClient.on('first_success', callback);
       watchClient.start('--noClear', '--out', './tmp/output.js', './tmp/fixtures/passing.ts');

--- a/test/runner.it.js
+++ b/test/runner.it.js
@@ -1,21 +1,21 @@
 const { expect } = require('chai');
 const runner = require('../lib/runner');
 
-describe.only('Runner', () => {
+describe('Runner', () => {
   it('Should start a long running process and kill it before it finishes', (done) => {
     const kill = runner('sleep 10')
-    setTimeout(function() {
-      kill().then(function(result) {
-        expect(result).to.deep.equal([0,null])
+    setTimeout(function () {
+      kill().then(function (result) {
+        expect(result).to.deep.equal([0, null])
         done()
       })
     }, 1)
   })
   it('Should start a short running process and not kill it before it finishes', (done) => {
     const kill = runner('echo')
-    setTimeout(function() {
-      kill().then(function(result) {
-        expect(result).to.deep.equal([1,0])
+    setTimeout(function () {
+      kill().then(function (result) {
+        expect(result).to.deep.equal([1, 0])
         done()
       })
     }, 5)

--- a/test/tsc-watch.it.js
+++ b/test/tsc-watch.it.js
@@ -9,6 +9,15 @@ describe('TSC-Watch child process messages', () => {
   beforeEach(() => (this.listener = sinon.stub()));
   afterEach(() => driver.reset());
 
+  it('Should send "started" on compilation start', () => {
+    driver
+      .subscribe('started', this.listener)
+      .startWatch()
+      .modifyAndSucceedAfter(1000);
+
+    return eventually(() => expect(this.listener.callCount).to.be.equal(1));
+  });
+
   it('Should send "first_success" on first success', () => {
     driver
       .subscribe('first_success', this.listener)

--- a/tsc-watch-client-example.js
+++ b/tsc-watch-client-example.js
@@ -2,6 +2,10 @@ const readline = require('readline');
 const TscWatchClient = require('./client');
 const client = new TscWatchClient();
 
+client.on('started', () => {
+  console.log('Compilation started');
+});
+
 client.on('first_success', () => {
   console.log('Interactive mode');
   console.log('  Press "r" to re-run the onSuccess command, esc to exit.\n');


### PR DESCRIPTION
- Implement the idea in https://github.com/gilamran/tsc-watch/issues/120
- Enable all existing unit tests (it seems like they were accidentally disabled by committing describe.only), fix broken ones
- Add new unit tests for --onCompilationStarted
- Make CHANGELOG.md to look stylistically consistently
- In the code, rename newCompilation* variables to compilationStarted* to make naming more consistent with compilationComplete* variable

Also, additionally tested this PR manually with:

```bash
node ./index.js test/fixtures/failing.ts --outDir ./dist --onCompilationStarted "echo STARTED" --onSuccess "echo SUCCESS"
node ./tsc-watch-client-example.js
```

P.S.
The usecase explanation for this new --onCompilationStarted option on my end is here: https://github.com/webpack/webpack/issues/13978

In short, I want to have a file in dist/ which contains: a) "started" when the compilation is ongoing, b) "success" when it's successful, and c) "compile_errors" when the compilation has errors. Having this file up to date, I can then teach other build tools in the chain (like webpack) to unfreeze their monorepo multi-package watch work on changes only when ALL the files in monorepo contain "success".