### PR TITLE
feat: add --silent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 | `--onCompilationComplete COMMAND` | Executes `COMMAND` on **every successful or failed** compilation. |
 | `--noColors` | By default tsc-watch adds colors the output with green<br>on success, and in red on failure. <br>Add this argument to prevent that. |
 | `--noClear` | In watch mode the `tsc` compiler clears the screen before reporting<br>Add this argument to prevent that. |
+| `--silent` | Do not print any messages on stdout. |
 | `--compiler PATH` | The `PATH` will be used instead of typescript compiler.<br>Default is `typescript/bin/tsc` |
 
 Notes:

--- a/lib/args-manager.js
+++ b/lib/args-manager.js
@@ -52,6 +52,7 @@ function extractArgs(args) {
   const onCompilationComplete = extractCommandWithValue(allArgs, '--onCompilationComplete');
   const noColors = extractCommand(allArgs, '--noColors');
   const noClear = extractCommand(allArgs, '--noClear');
+  const silent = extractCommand(allArgs, '--silent');
   let compiler = extractCommandWithValue(allArgs, '--compiler');
   if (!compiler) {
     compiler = 'typescript/bin/tsc';
@@ -67,6 +68,7 @@ function extractArgs(args) {
     onCompilationComplete: onCompilationComplete,
     noColors: noColors,
     noClear: noClear,
+    silent: silent,
     compiler: compiler,
     args: allArgs,
   };

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -23,6 +23,7 @@ const {
   onCompilationComplete,
   noColors,
   noClear,
+  silent,
   compiler,
   args,
 } = extractArgs(process.argv);
@@ -90,7 +91,7 @@ rl.on('line', function (input) {
   }
 
   const line = manipulate(input);
-  print(noColors, noClear, line);
+  if (!silent) print(noColors, noClear, line);
   const state = detectState(line);
   const compilationStarted = state.compilationStarted;
   const compilationError = state.compilationError;

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -91,7 +91,9 @@ rl.on('line', function (input) {
   }
 
   const line = manipulate(input);
-  if (!silent) print(noColors, noClear, line);
+  if (!silent) {
+    print(noColors, noClear, line);
+  }
   const state = detectState(line);
   const compilationStarted = state.compilationStarted;
   const compilationError = state.compilationError;

--- a/test/args-manager.it.js
+++ b/test/args-manager.it.js
@@ -63,6 +63,11 @@ describe('Args Manager', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).noClear).to.eq(false);
     expect(extractArgs(['node', 'tsc-watch.js', '--noClear', '1.ts']).noClear).to.eq(true);
   });
+  
+  it('Should return the silent', () => {
+    expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).silent).to.eq(false);
+    expect(extractArgs(['node', 'tsc-watch.js', '--silent', '1.ts']).silent).to.eq(true);
+  });
 
   it('Should return the compiler', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).compiler).to.eq('typescript/bin/tsc');


### PR DESCRIPTION
This adds another option: `--silent`. This option enables you not to show any logs on the console.

I'm using this module as a library on [Glee](https://www.github.com/asyncapi/glee) and the compilation is a process that should happen behind the scenes, without the user noticing.

I thought this would be useful for others too.

Cheers, and thanks for the great work! 🙌 