### PR TITLE
Add `--maxNodeMem` param to tweak node tsc allocated memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | `--onFailure COMMAND` | Executes `COMMAND` on **every failed** compilation. |
 | `--onCompilationStarted COMMAND` | Executes `COMMAND` on **every compilation start** event (initial and incremental). |
 | `--onCompilationComplete COMMAND` | Executes `COMMAND` on **every successful or failed** compilation. |
+| `--maxNodeMem` | Call `node` with a specific memory limit `max_old_space_size`, to use if your project needs more memory. |
 | `--noColors` | By default tsc-watch adds colors the output with green<br>on success, and in red on failure. <br>Add this argument to prevent that. |
 | `--noClear` | In watch mode the `tsc` compiler clears the screen before reporting<br>Add this argument to prevent that. |
 | `--silent` | Do not print any messages on stdout. |

--- a/lib/args-manager.js
+++ b/lib/args-manager.js
@@ -50,6 +50,7 @@ function extractArgs(args) {
   const onFailureCommand = extractCommandWithValue(allArgs, '--onFailure');
   const onCompilationStarted = extractCommandWithValue(allArgs, '--onCompilationStarted');
   const onCompilationComplete = extractCommandWithValue(allArgs, '--onCompilationComplete');
+  const maxNodeMem = extractCommandWithValue(allArgs, '--maxNodeMem');
   const noColors = extractCommand(allArgs, '--noColors');
   const noClear = extractCommand(allArgs, '--noClear');
   const silent = extractCommand(allArgs, '--silent');
@@ -66,6 +67,7 @@ function extractArgs(args) {
     onFailureCommand: onFailureCommand,
     onCompilationStarted: onCompilationStarted,
     onCompilationComplete: onCompilationComplete,
+    maxNodeMem: maxNodeMem,
     noColors: noColors,
     noClear: noClear,
     silent: silent,

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -21,6 +21,7 @@ const {
   onFailureCommand,
   onCompilationStarted,
   onCompilationComplete,
+  maxNodeMem,
   noColors,
   noClear,
   silent,
@@ -68,7 +69,7 @@ function runOnSuccessCommand() {
   }
 }
 
-function buildNodeParams(allArgs){
+function buildNodeParams(allArgs, { maxNodeMem }){
   let tscBin;
   try {
     tscBin = require.resolve(compiler);
@@ -81,13 +82,14 @@ function buildNodeParams(allArgs){
   }
 
   return [
+    ...((maxNodeMem) ? [`--max_old_space_size=${maxNodeMem}`] : []),
     tscBin,
     ...allArgs,
   ];
 }
 
 let compilationErrorSinceStart = false;
-const tscProcess = spawn('node', buildNodeParams(args));
+const tscProcess = spawn('node', buildNodeParams(args, { maxNodeMem }));
 const rl = readline.createInterface({
   input: tscProcess.stdout,
 });

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -68,19 +68,26 @@ function runOnSuccessCommand() {
   }
 }
 
-let bin;
-try {
-  bin = require.resolve(compiler);
-} catch (e) {
-  if (e.code === 'MODULE_NOT_FOUND') {
-    console.error(e.message);
-    process.exit(9);
+function buildNodeParams(allArgs){
+  let bin;
+  try {
+    bin = require.resolve(compiler);
+  } catch (e) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      console.error(e.message);
+      process.exit(9);
+    }
+    throw e;
   }
-  throw e;
+
+  return [
+    bin,
+    ...allArgs,
+  ];
 }
 
 let compilationErrorSinceStart = false;
-const tscProcess = spawn('node', [bin, ...args]);
+const tscProcess = spawn('node', buildNodeParams(args));
 const rl = readline.createInterface({
   input: tscProcess.stdout,
 });

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -69,9 +69,9 @@ function runOnSuccessCommand() {
 }
 
 function buildNodeParams(allArgs){
-  let bin;
+  let tscBin;
   try {
-    bin = require.resolve(compiler);
+    tscBin = require.resolve(compiler);
   } catch (e) {
     if (e.code === 'MODULE_NOT_FOUND') {
       console.error(e.message);
@@ -81,7 +81,7 @@ function buildNodeParams(allArgs){
   }
 
   return [
-    bin,
+    tscBin,
     ...allArgs,
   ];
 }

--- a/test/args-manager.it.js
+++ b/test/args-manager.it.js
@@ -54,6 +54,11 @@ describe('Args Manager', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '--onCompilationComplete', 'COMMAND_TO_RUN', '1.ts']).onCompilationComplete).to.eq('COMMAND_TO_RUN');
   });
 
+  it('Should return the maxNodeMem', () => {
+    expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).maxNodeMem).to.eq(null);
+    expect(extractArgs(['node', 'tsc-watch.js', '--maxNodeMem', '1024']).maxNodeMem).to.eq('1024');
+  });
+
   it('Should return the noColors', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).noColors).to.eq(false);
     expect(extractArgs(['node', 'tsc-watch.js', '--noColors', '1.ts']).noColors).to.eq(true);
@@ -63,7 +68,7 @@ describe('Args Manager', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).noClear).to.eq(false);
     expect(extractArgs(['node', 'tsc-watch.js', '--noClear', '1.ts']).noClear).to.eq(true);
   });
-  
+
   it('Should return the silent', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).silent).to.eq(false);
     expect(extractArgs(['node', 'tsc-watch.js', '--silent', '1.ts']).silent).to.eq(true);


### PR DESCRIPTION
Issue: https://github.com/gilamran/tsc-watch/issues/137

Read issue for more, in short:
- Add new param `--maxNodeMem 1234`
- If this param is set, call  `node` with additional mem tweak `--max_old_space_size=1234`
