### PR TITLE
Support  for `--listEmittedFiles` + new message `file_emitted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @gilamran/tsc-watch CHANGELOG
 
+## v4.6.2 - 10/01/2022
+
+- Added tsc `--listEmittedFiles` support [issue](https://github.com/gilamran/tsc-watch/issues/138)
+- Added client new event `file_emitted` with the emitted file path
+
+## v4.6.1 - 09/01/2022
+
+- Added `--maxNodeMem` param to set manually node allocated memory [issue](https://github.com/gilamran/tsc-watch/issues/137)
+
 ## v4.6.0 - 20/12/2021
 
 - Added `silent` option - (Thanks to @axtk for the idea and @fmvilas for the PR)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | `--onFailure COMMAND` | Executes `COMMAND` on **every failed** compilation. |
 | `--onCompilationStarted COMMAND` | Executes `COMMAND` on **every compilation start** event (initial and incremental). |
 | `--onCompilationComplete COMMAND` | Executes `COMMAND` on **every successful or failed** compilation. |
-| `--maxNodeMem` | Call `node` with a specific memory limit `max_old_space_size`, to use if your project needs more memory. |
+| `--maxNodeMem` | Calls `node` with a specific memory limit `max_old_space_size`, to use if your project needs more memory. |
 | `--noColors` | By default tsc-watch adds colors the output with green<br>on success, and in red on failure. <br>Add this argument to prevent that. |
 | `--noClear` | In watch mode the `tsc` compiler clears the screen before reporting<br>Add this argument to prevent that. |
 | `--silent` | Do not print any messages on stdout. |
@@ -70,6 +70,7 @@ The client is implemented as an instance of `Node.JS`'s `EventEmitter`, with the
 - `first_success` - Emitted upon first successful compilation.
 - `subsequent_success` - Emitted upon every subsequent successful compilation.
 - `compile_errors` - Emitted upon every failing compilation.
+- `file_emitted` - Emitted upon every file transpiled if `--listEmittedFiles` is used.
 
 Once subscribed to the relevant events, start the client by running `watch.start()`
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,10 +1,11 @@
-const { fork } = require('child_process');
+const child_process = require('child_process');
 const EventEmitter = require('events');
 
 class TscWatchClient extends EventEmitter {
   start(...args) {
-    this.tsc = fork(require.resolve('./tsc-watch.js'), args, { stdio: 'inherit' });
-    this.tsc.on('message', (msg) => this.emit(msg));
+    this.tsc = child_process.fork(require.resolve('./tsc-watch.js'), args, { stdio: 'inherit' });
+    this.tsc.on('message', (msg) => this.emit(...deserializeTscMessage(msg)));
+    this.tsc.on('exit', (code, signal) => this.emit('exit', code, signal));
   }
 
   kill() {
@@ -43,6 +44,15 @@ class TscWatchClient extends EventEmitter {
       this.tsc.send('run-on-success-command');
     }
   }
+}
+
+function deserializeTscMessage(strMsg){
+  const indexOfSeparator = strMsg.indexOf(':');
+  if(indexOfSeparator === -1){
+    return [strMsg];
+  }
+
+  return [strMsg.substring(0, indexOfSeparator), strMsg.substring(indexOfSeparator + 1)]
 }
 
 module.exports = TscWatchClient;

--- a/lib/stdout-manipulator.js
+++ b/lib/stdout-manipulator.js
@@ -3,6 +3,7 @@ const stripAnsi = require('strip-ansi');
 const tscUsageSyntaxRegex = / -w, --watch.*Watch input files\./;
 const typescriptPrettyErrorRegex = /:\d+:\d+ \- error TS\d+: /;
 const typescriptErrorRegex = /\(\d+,\d+\): error TS\d+: /;
+const typescriptEmittedFileRegex = /(TSFILE:)\s*(.*)/;
 
 const compilationCompleteWithErrorRegex = / Found [^0][0-9]* error[s]?\. Watching for file changes\./;
 const compilationCompleteWithoutErrorRegex = / Found 0 errors\. Watching for file changes\./;
@@ -35,6 +36,9 @@ function color(line, noClear) {
   // usage
   line = line.replace(tscUsageSyntaxRegex, m => `\u001B[33m${m}\u001B[39m`); // Yellow
 
+  // file emitted
+  line = line.replace(typescriptEmittedFileRegex, (_0, stdPrefix, file) => `\u001B[30m\u001B[4m${stdPrefix}\u001B[0m \u001B[30m${file}\u001B[0m`); // Grey underlined / Grey
+
   if (noClear && compilationStartedRegex.test(line)) {
     return '\n\n----------------------\n' + line;
   }
@@ -66,11 +70,14 @@ function detectState(line) {
     typescriptErrorRegex.test(clearLine) ||
     typescriptPrettyErrorRegex.test(clearLine);
   const compilationComplete = compilationCompleteRegex.test(clearLine);
+  const fileEmittedExec = typescriptEmittedFileRegex.exec(clearLine);
+  const fileEmitted = fileEmittedExec ? fileEmittedExec[2] : null;
 
   return {
     compilationStarted: compilationStarted,
     compilationError: compilationError,
     compilationComplete: compilationComplete,
+    fileEmitted: fileEmitted,
   };
 }
 

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -110,6 +110,11 @@ rl.on('line', function (input) {
 
   compilationErrorSinceStart = (!compilationStarted && compilationErrorSinceStart) || compilationError;
 
+  if(state.fileEmitted !== null){
+    Signal.emitFile(state.fileEmitted);
+    return;
+  }
+
   if (compilationStarted) {
     killProcesses(false).then(() => {
       runOnCompilationStarted();
@@ -184,6 +189,7 @@ const Signal = {
   emitFirstSuccess: () => Signal.send('first_success'),
   emitSuccess: () => Signal.send('success'),
   emitFail: () => Signal.send('compile_errors'),
+  emitFile: (path) => Signal.send(`file_emitted:${path}`),
 };
 
 nodeCleanup((_exitCode, signal) => {

--- a/test/stdout-manipulator.it.js
+++ b/test/stdout-manipulator.it.js
@@ -1,0 +1,42 @@
+const child_process = require('child_process');
+const { expect } = require('chai');
+const { detectState } = require('../lib/stdout-manipulator');
+
+describe('stdout-manipulator', () => {
+    describe('detectState', () => {
+        it('Should not detect anything for an empty line', async () => {
+            const state = detectState('');
+            expect(state).to.deep.equal({
+                compilationStarted: false,
+                compilationError: false,
+                compilationComplete: false,
+            });
+        });
+
+        it('Should not detect anything for an unknown line', async () => {
+            const state = detectState('tsc: unknown statement');
+            expect(state).to.deep.equal({
+                compilationStarted: false,
+                compilationError: false,
+                compilationComplete: false,
+            });
+        });
+
+        describe('Tested with typescript 4.5.5', () => {
+            it('Should detect a compilation start', async () => {
+                const { compilationStarted } = detectState('[\x1B[90m11:32:11 AM\x1B[0m] Starting compilation in watch mode...');
+                expect(compilationStarted).to.equal(true);
+            });
+
+            it('Should detect a compilation error', async () => {
+                const { compilationError } = detectState('\x1B[96mmodules/file.ts\x1B[0m:\x1B[93m17\x1B[0m:\x1B[93m49\x1B[0m - \x1B[91merror\x1B[0m\x1B[90m TS2345: \x1B[0mArgument of type \'string\' is not assignable to parameter of type \'never\'.');
+                expect(compilationError).to.equal(true);
+            });
+
+            it('Should detect a compilation complete', async () => {
+                const { compilationComplete } = detectState('[\x1B[90m11:32:26 AM\x1B[0m] Found 4 errors. Watching for file changes.');
+                expect(compilationComplete).to.equal(true);
+            });
+        })
+    });
+});

--- a/test/stdout-manipulator.it.js
+++ b/test/stdout-manipulator.it.js
@@ -10,6 +10,7 @@ describe('stdout-manipulator', () => {
                 compilationStarted: false,
                 compilationError: false,
                 compilationComplete: false,
+                fileEmitted: null,
             });
         });
 
@@ -19,6 +20,7 @@ describe('stdout-manipulator', () => {
                 compilationStarted: false,
                 compilationError: false,
                 compilationComplete: false,
+                fileEmitted: null,
             });
         });
 
@@ -36,6 +38,11 @@ describe('stdout-manipulator', () => {
             it('Should detect a compilation complete', async () => {
                 const { compilationComplete } = detectState('[\x1B[90m11:32:26 AM\x1B[0m] Found 4 errors. Watching for file changes.');
                 expect(compilationComplete).to.equal(true);
+            });
+
+            it('Should detect an emitted file', async () => {
+                const { fileEmitted } = detectState('TSFILE: /my/dist/hello.js');
+                expect(fileEmitted).to.equal('/my/dist/hello.js');
             });
         })
     });


### PR DESCRIPTION
Issue: https://github.com/gilamran/tsc-watch/issues/138 read for more
What does this PR:

- Handle `--listEmittedFiles` param and call `tsc` accordingly
- Update `tsc-watch` to send `file_emitted:<filepath>`
- Make client emit `file_emitted:` with the `<filePath>`

I've put grey color because TSFILE are not very important see
![Screenshot from 2022-03-10 11-20-08](https://user-images.githubusercontent.com/572334/157676033-71e33e5a-864c-4ba1-89c5-34bb024ca5ad.png)

(Tests are passing)
![Screenshot from 2022-03-10 14-26-22](https://user-images.githubusercontent.com/572334/157676098-fd06711e-5289-4926-a073-29137abcb305.png)

