### PR TITLE
feat(136): improve error handling on tsc fatal signals

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { ChildProcess, fork, ForkOptions } from 'child_process';
 import { EventEmitter } from 'events';
 
-const tscWatchLibPath = require.resolve(path.resolve(__dirname, '..', 'lib', 'tsc-watch'));
+const tscWatchLibPath = path.join(__dirname, '..', 'lib', 'tsc-watch');
 
 export class TscWatchClient extends EventEmitter {
   private tsc: ChildProcess | undefined;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -17,7 +17,7 @@ export class TscWatchClient extends EventEmitter {
     this.tsc.on('message', (msg: string) => {
       this.emit(...deserializeTscMessage(msg));
     });
-    this.tsc.on('exit', (code: number, signal: number) => {
+    this.tsc.on('exit', (code: number, signal: string) => {
       this.emit('exit', code, signal);
     });
   }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,10 +1,13 @@
+import * as path from 'path';
 import { ChildProcess, fork, ForkOptions } from 'child_process';
 import { EventEmitter } from 'events';
+
+const tscWatchLibPath = require.resolve(path.resolve(__dirname, '..', 'lib', 'tsc-watch'));
 
 export class TscWatchClient extends EventEmitter {
   private tsc: ChildProcess | undefined;
 
-  constructor(private tscWatchPath: string = require.resolve('tsc-watch')) {
+  constructor(private tscWatchPath = tscWatchLibPath) {
     super();
   }
 

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -107,8 +107,11 @@ function echoExit(code: number | null, signal: string | null) {
 
 let compilationErrorSinceStart = false;
 const tscProcess = spawnTsc({ maxNodeMem }, args);
-if (!tscProcess.stderr || !tscProcess.stdout) {
+if (!tscProcess.stdout) {
   throw new Error('Unable to read Typescript stdout');
+}
+if (!tscProcess.stderr) {
+  throw new Error('Unable to read Typescript stderr');
 }
 
 tscProcess.on('exit', echoExit);

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -99,11 +99,20 @@ function spawnTsc({ maxNodeMem }: INodeSettings, args: string[]): ChildProcess {
   return spawn('node', nodeArgs);
 }
 
+function echoExit(code: number | null, signal: string | null) {
+  if (signal !== null) {
+    process.kill(process.pid, signal);
+  }
+}
+
 let compilationErrorSinceStart = false;
 const tscProcess = spawnTsc({ maxNodeMem }, args);
-if (!tscProcess.stdout) {
+if (!tscProcess.stderr || !tscProcess.stdout) {
   throw new Error('Unable to read Typescript stdout');
 }
+
+tscProcess.on('exit', echoExit);
+tscProcess.stderr.pipe(process.stderr);
 
 const rl = createInterface({ input: tscProcess.stdout });
 
@@ -199,7 +208,7 @@ const sendSignal = (msg: string) => {
   if (process.send) {
     process.send(msg);
   }
-}
+};
 
 const Signal = {
   emitStarted: () => sendSignal('started'),

--- a/src/test/client.test.ts
+++ b/src/test/client.test.ts
@@ -8,6 +8,9 @@ import {
   removeFixtures,
   waitFor,
 } from './test-utils';
+import type { ChildProcess } from 'child_process';
+
+const child_process = require('child_process');
 
 describe('Client Events', () => {
   let watchClient: TscWatchClient;
@@ -60,6 +63,21 @@ describe('Client Events', () => {
       watchClient.on('compile_errors', callback);
       watchClient.start('--noClear', '--out', OUTPUT_FILE, FAILING_FILE);
       return waitFor(() => callback.mock.calls.length > 0);
+    });
+
+    it('Should fire back "exit" event when the process is exited by a signal', async function () {
+      const forkSpy = jest.spyOn(child_process, 'fork');
+      watchClient.on('exit', callback);
+      watchClient.start('--noClear', '--out', OUTPUT_FILE, PASSING_FILE);
+      const tscProcess: ChildProcess = forkSpy.mock.results[0].value;
+
+      // Wait tsc-watch to be started and bound before to kill process
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      process.kill(tscProcess.pid, 6);
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await waitFor(() => callback.mock.calls.length > 0);
+      expect(callback.mock.calls[0]).toEqual([null, 'SIGABRT']);
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/gilamran/tsc-watch/issues/136 (exhaustive issue)

Improved client error handling:
- when `tsc-watch.js` crashes with a signal (`SIGKILL`, `SIGABRT`), it will kill it with the **same signal**
- `tsc` stderr was lost for parent processes - it's now piped to the tsc-watch stderr

Purpose of this PR is to not make devs spend time finding out why tsc crash behing TscWatchClient / tsc-watch.
Probably everybody expect this behavior (do they? I hope so), in any case we are making it part of v6 major