### PR TITLE
feat(140): add `--signalEmittedFiles` and trigger `file_emitted` silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | `--maxNodeMem` | Calls `node` with a specific memory limit `max_old_space_size`, to use if your project needs more memory. |
 | `--noColors` | By default tsc-watch adds colors the output with green<br>on success, and in red on failure. <br>Add this argument to prevent that. |
 | `--noClear` | In watch mode the `tsc` compiler clears the screen before reporting<br>Add this argument to prevent that. |
+| `--signalEmittedFiles` | Will run `tsc` compiler with `--listEmittedFiles`, but hiding TSFILE lines. Use it to enable `file_emitted` event, while keeping tsc stdout silent. |
 | `--silent` | Do not print any messages on stdout. |
 | `--compiler PATH` | The `PATH` will be used instead of typescript compiler.<br>Default is `typescript/bin/tsc` |
 

--- a/src/lib/args-manager.ts
+++ b/src/lib/args-manager.ts
@@ -54,7 +54,8 @@ export function extractArgs(inputArgs: string[]) {
   const noColors = extractCommand(args, '--noColors');
   const noClear = extractCommand(args, '--noClear');
   const silent = extractCommand(args, '--silent');
-  const signalEmittedFiles = extractCommand(args, '--signalEmittedFiles') && !args.includes('--listEmittedFiles');
+  const signalEmittedFiles = extractCommand(args, '--signalEmittedFiles');
+  const requestedToListEmittedFiles = extractCommand(args, '--listEmittedFiles');
   let compiler = extractCommandWithValue(args, '--compiler');
   if (!compiler) {
     compiler = 'typescript/bin/tsc';
@@ -71,6 +72,7 @@ export function extractArgs(inputArgs: string[]) {
     maxNodeMem,
     noColors,
     noClear,
+    requestedToListEmittedFiles,
     signalEmittedFiles,
     silent,
     compiler,

--- a/src/lib/args-manager.ts
+++ b/src/lib/args-manager.ts
@@ -54,6 +54,7 @@ export function extractArgs(inputArgs: string[]) {
   const noColors = extractCommand(args, '--noColors');
   const noClear = extractCommand(args, '--noClear');
   const silent = extractCommand(args, '--silent');
+  const signalEmittedFiles = extractCommand(args, '--signalEmittedFiles');
   let compiler = extractCommandWithValue(args, '--compiler');
   if (!compiler) {
     compiler = 'typescript/bin/tsc';
@@ -70,6 +71,7 @@ export function extractArgs(inputArgs: string[]) {
     maxNodeMem,
     noColors,
     noClear,
+    signalEmittedFiles,
     silent,
     compiler,
     args,

--- a/src/lib/args-manager.ts
+++ b/src/lib/args-manager.ts
@@ -54,7 +54,7 @@ export function extractArgs(inputArgs: string[]) {
   const noColors = extractCommand(args, '--noColors');
   const noClear = extractCommand(args, '--noClear');
   const silent = extractCommand(args, '--silent');
-  const signalEmittedFiles = extractCommand(args, '--signalEmittedFiles');
+  const signalEmittedFiles = extractCommand(args, '--signalEmittedFiles') && !args.includes('--listEmittedFiles');
   let compiler = extractCommandWithValue(args, '--compiler');
   if (!compiler) {
     compiler = 'typescript/bin/tsc';

--- a/src/lib/stdout-manipulator.ts
+++ b/src/lib/stdout-manipulator.ts
@@ -57,6 +57,7 @@ function color(line: string, noClear: boolean = false): string {
 type TPrintParams = {
   noColors?: boolean;
   noClear?: boolean;
+  requestedToListEmittedFiles?: boolean;
   signalEmittedFiles?: boolean;
 };
 
@@ -65,9 +66,10 @@ export function print(
     {
       noColors = false,
       noClear = false,
-      signalEmittedFiles = false
+      requestedToListEmittedFiles = false,
+      signalEmittedFiles = false,
     }: TPrintParams = {}): void {
-  if (signalEmittedFiles && line.startsWith('TSFILE:')) {
+  if (signalEmittedFiles && !requestedToListEmittedFiles && line.startsWith('TSFILE:')) {
     return;
   }
 

--- a/src/lib/stdout-manipulator.ts
+++ b/src/lib/stdout-manipulator.ts
@@ -54,9 +54,22 @@ function color(line: string, noClear: boolean = false): string {
   return line;
 }
 
-export function print(noColors: boolean, noClear: boolean, line: string, signalEmittedFiles: boolean): void {
-  const outputLine = noColors ? line : color(line, noClear);
-  if (signalEmittedFiles && outputLine.startsWith('TSFILE:')) { return; }
+type PrintParams = {
+  noColors?: boolean;
+  noClear?: boolean;
+  signalEmittedFiles?: boolean;
+};
+
+export function print(
+    line: string,
+    {
+      noColors = false,
+      noClear = false,
+      signalEmittedFiles = false
+    }: PrintParams = {}): void {
+  if (signalEmittedFiles && line.startsWith('TSFILE:')) {
+    return;
+  }
 
   console.log(noColors ? line : color(line, noClear));
 }

--- a/src/lib/stdout-manipulator.ts
+++ b/src/lib/stdout-manipulator.ts
@@ -1,7 +1,7 @@
 const ANSI_REGEX = new RegExp('[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))', 'g');
 const stripAnsi = (str: string) => str.replace(ANSI_REGEX, '');
-  
-  
+
+
 const tscUsageSyntaxRegex = / -w, --watch.*Watch input files\./;
 const typescriptPrettyErrorRegex = /:\d+:\d+ \- error TS\d+: /;
 const typescriptErrorRegex = /\(\d+,\d+\): error TS\d+: /;
@@ -54,7 +54,10 @@ function color(line: string, noClear: boolean = false): string {
   return line;
 }
 
-export function print(noColors: boolean, noClear: boolean, line: string): void {
+export function print(noColors: boolean, noClear: boolean, line: string, signalEmittedFiles: boolean): void {
+  const outputLine = noColors ? line : color(line, noClear);
+  if (signalEmittedFiles && outputLine.startsWith('TSFILE:')) { return; }
+
   console.log(noColors ? line : color(line, noClear));
 }
 

--- a/src/lib/stdout-manipulator.ts
+++ b/src/lib/stdout-manipulator.ts
@@ -54,7 +54,7 @@ function color(line: string, noClear: boolean = false): string {
   return line;
 }
 
-type PrintParams = {
+type TPrintParams = {
   noColors?: boolean;
   noClear?: boolean;
   signalEmittedFiles?: boolean;
@@ -66,7 +66,7 @@ export function print(
       noColors = false,
       noClear = false,
       signalEmittedFiles = false
-    }: PrintParams = {}): void {
+    }: TPrintParams = {}): void {
   if (signalEmittedFiles && line.startsWith('TSFILE:')) {
     return;
   }

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -24,6 +24,7 @@ const {
   maxNodeMem,
   noColors,
   noClear,
+  signalEmittedFiles,
   silent,
   compiler,
   args,
@@ -84,12 +85,16 @@ function getTscPath(): string {
 
 interface INodeSettings {
   maxNodeMem: string | null;
+  signalEmittedFiles: boolean;
 }
 
-function spawnTsc({ maxNodeMem }: INodeSettings, args: string[]): ChildProcess {
+function spawnTsc({ maxNodeMem, signalEmittedFiles }: INodeSettings, args: string[]): ChildProcess {
   const nodeArgs = [];
   if (maxNodeMem) {
     nodeArgs.push(`--max_old_space_size=${maxNodeMem}`);
+  }
+  if (signalEmittedFiles) {
+    nodeArgs.push(`--listEmittedFiles`);
   }
 
   const tscBin = getTscPath();
@@ -100,7 +105,7 @@ function spawnTsc({ maxNodeMem }: INodeSettings, args: string[]): ChildProcess {
 }
 
 let compilationErrorSinceStart = false;
-const tscProcess = spawnTsc({ maxNodeMem }, args);
+const tscProcess = spawnTsc({ maxNodeMem, signalEmittedFiles }, args);
 if (!tscProcess.stdout) {
   throw new Error('Unable to read Typescript stdout');
 }
@@ -114,7 +119,7 @@ rl.on('line', function (input) {
 
   const line = manipulate(input);
   if (!silent) {
-    print(noColors, noClear, line);
+    print(noColors, noClear, line, signalEmittedFiles);
   }
   const state = detectState(line);
   const compilationStarted = state.compilationStarted;

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -24,6 +24,7 @@ const {
   maxNodeMem,
   noColors,
   noClear,
+  requestedToListEmittedFiles,
   signalEmittedFiles,
   silent,
   compiler,
@@ -85,15 +86,16 @@ function getTscPath(): string {
 
 interface INodeSettings {
   maxNodeMem: string | null;
+  requestedToListEmittedFiles: boolean;
   signalEmittedFiles: boolean;
 }
 
-function spawnTsc({ maxNodeMem, signalEmittedFiles }: INodeSettings, args: string[]): ChildProcess {
+function spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles }: INodeSettings, args: string[]): ChildProcess {
   const nodeArgs = [];
   if (maxNodeMem) {
     nodeArgs.push(`--max_old_space_size=${maxNodeMem}`);
   }
-  if (signalEmittedFiles) {
+  if (signalEmittedFiles && !requestedToListEmittedFiles) {
     nodeArgs.push(`--listEmittedFiles`);
   }
 
@@ -105,7 +107,7 @@ function spawnTsc({ maxNodeMem, signalEmittedFiles }: INodeSettings, args: strin
 }
 
 let compilationErrorSinceStart = false;
-const tscProcess = spawnTsc({ maxNodeMem, signalEmittedFiles }, args);
+const tscProcess = spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles }, args);
 if (!tscProcess.stdout) {
   throw new Error('Unable to read Typescript stdout');
 }
@@ -119,7 +121,7 @@ rl.on('line', function (input) {
 
   const line = manipulate(input);
   if (!silent) {
-    print(line, { noColors, noClear, signalEmittedFiles });
+    print(line, { noColors, noClear, signalEmittedFiles, requestedToListEmittedFiles });
   }
   const state = detectState(line);
   const compilationStarted = state.compilationStarted;

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -119,7 +119,7 @@ rl.on('line', function (input) {
 
   const line = manipulate(input);
   if (!silent) {
-    print(noColors, noClear, line, signalEmittedFiles);
+    print(line, { noColors, noClear, signalEmittedFiles });
   }
   const state = detectState(line);
   const compilationStarted = state.compilationStarted;

--- a/src/test/args-manager.test.ts
+++ b/src/test/args-manager.test.ts
@@ -120,6 +120,10 @@ describe('Args Manager', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '--signalEmittedFiles', '1.ts']).signalEmittedFiles).toBe(true);
   });
 
+  it('Should not return conflicting signalEmittedFiles if --listEmittedFiles is specifically flagged', () => {
+    expect(extractArgs(['node', 'tsc-watch.js', '--signalEmittedFiles', '--listEmittedFiles', '1.ts']).signalEmittedFiles).toBe(false);
+  });
+
   it('Should return the compiler', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).compiler).toBe('typescript/bin/tsc');
     expect(

--- a/src/test/args-manager.test.ts
+++ b/src/test/args-manager.test.ts
@@ -120,8 +120,9 @@ describe('Args Manager', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '--signalEmittedFiles', '1.ts']).signalEmittedFiles).toBe(true);
   });
 
-  it('Should not return conflicting signalEmittedFiles if --listEmittedFiles is specifically flagged', () => {
-    expect(extractArgs(['node', 'tsc-watch.js', '--signalEmittedFiles', '--listEmittedFiles', '1.ts']).signalEmittedFiles).toBe(false);
+  it('Should return requestedToListEmittedFiles when tsc native listEmittedFiles is set', () => {
+    expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).requestedToListEmittedFiles).toBe(false);
+    expect(extractArgs(['node', 'tsc-watch.js', '--listEmittedFiles', '1.ts']).requestedToListEmittedFiles).toBe(true);
   });
 
   it('Should return the compiler', () => {

--- a/src/test/args-manager.test.ts
+++ b/src/test/args-manager.test.ts
@@ -115,6 +115,11 @@ describe('Args Manager', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '--silent', '1.ts']).silent).toBe(true);
   });
 
+  it('Should return the signalEmittedFiles', () => {
+    expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).signalEmittedFiles).toBe(false);
+    expect(extractArgs(['node', 'tsc-watch.js', '--signalEmittedFiles', '1.ts']).signalEmittedFiles).toBe(true);
+  });
+
   it('Should return the compiler', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).compiler).toBe('typescript/bin/tsc');
     expect(

--- a/src/test/stdout-manipulator.test.ts
+++ b/src/test/stdout-manipulator.test.ts
@@ -60,14 +60,21 @@ describe('stdout-manipulator', () => {
             expect(forkSpy.mock.calls).toEqual([['raw tsc line']])
         });
 
-        it('Should hide a TSFILE line when signalEmittedFiles is true', async () => {
-            print('TSFILE: /home/emitted/file.js', { signalEmittedFiles: true });
-            expect(forkSpy.mock.calls).toEqual([])
-        });
-
         it('Should not hide a normal line when signalEmittedFiles is true', async () => {
             print('any other line', { signalEmittedFiles: true });
             expect(forkSpy.mock.calls).toEqual([['any other line']])
+        });
+
+        describe("TSFILE support", () => {
+            it('Should hide a TSFILE line when signalEmittedFiles is true', async () => {
+                print('TSFILE: /home/emitted/file.js', { signalEmittedFiles: true });
+                expect(forkSpy.mock.calls).toEqual([])
+            });
+
+            it('Should not hide a TSFILE line when signalEmittedFiles is true and native --listEmittedFiles (requestedToListEmittedFiles) is true', async () => {
+                print('TSFILE: /home/emitted/file.js', { noColors: true, signalEmittedFiles: true, requestedToListEmittedFiles: true });
+                expect(forkSpy.mock.calls).toEqual([['TSFILE: /home/emitted/file.js']])
+            });
         });
     });
 });

--- a/src/test/stdout-manipulator.test.ts
+++ b/src/test/stdout-manipulator.test.ts
@@ -1,4 +1,4 @@
-import { detectState } from '../lib/stdout-manipulator';
+import { detectState, print } from '../lib/stdout-manipulator';
 
 describe('stdout-manipulator', () => {
     describe('detectState', () => {
@@ -43,5 +43,31 @@ describe('stdout-manipulator', () => {
                 expect(fileEmitted).toEqual('/my/dist/hello.js');
             });
         })
+    });
+
+    describe('print', () => {
+        let forkSpy: any;
+        beforeEach(() => {
+            forkSpy = jest.spyOn(global.console, 'log').mockImplementation();
+        });
+
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('Should log raw line with default params', async () => {
+            print(true, true, 'raw tsc line', false);
+            expect(forkSpy.mock.calls).toEqual([['raw tsc line']])
+        });
+
+        it('Should hide a TSFILE line when signalEmittedFiles is true', async () => {
+            print(true, true, 'TSFILE: /home/emitted/file.js', true);
+            expect(forkSpy.mock.calls).toEqual([])
+        });
+
+        it('Should not hide a normal line when signalEmittedFiles is true', async () => {
+            print(true, true, 'any other line', true);
+            expect(forkSpy.mock.calls).toEqual([['any other line']])
+        });
     });
 });

--- a/src/test/stdout-manipulator.test.ts
+++ b/src/test/stdout-manipulator.test.ts
@@ -56,17 +56,17 @@ describe('stdout-manipulator', () => {
         });
 
         it('Should log raw line with default params', async () => {
-            print(true, true, 'raw tsc line', false);
+            print('raw tsc line');
             expect(forkSpy.mock.calls).toEqual([['raw tsc line']])
         });
 
         it('Should hide a TSFILE line when signalEmittedFiles is true', async () => {
-            print(true, true, 'TSFILE: /home/emitted/file.js', true);
+            print('TSFILE: /home/emitted/file.js', { signalEmittedFiles: true });
             expect(forkSpy.mock.calls).toEqual([])
         });
 
         it('Should not hide a normal line when signalEmittedFiles is true', async () => {
-            print(true, true, 'any other line', true);
+            print('any other line', { signalEmittedFiles: true });
             expect(forkSpy.mock.calls).toEqual([['any other line']])
         });
     });


### PR DESCRIPTION
In #140 I've added support to new event `.on(`file_emitted`)`. This feature works as long `--listEmittedFiles` param is set.
Problem: `--listEmittedFiles`is noisy and print a bunch of `TSFILE: /path/to/emitted/files.js`
@gilamran have suggested a new param `--signalEmittedFiles` which would make the event work, but silently.

### What's here
- parse `--signalEmittedFiles` (boolean)
- make it call tsc with `--listEmittedFiles`
- make it hide ines starting with `TSFILE:`