### PR TITLE
fix: v6 fixes

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/client"

--- a/client.js
+++ b/client.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/client');

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   },
   "files": [
     "dist/**/*",
-    "index.js"
+    "index.js",
+    "client.js",
+    "client.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/src/lib/stdout-manipulator.ts
+++ b/src/lib/stdout-manipulator.ts
@@ -41,12 +41,6 @@ function color(line: string, noClear: boolean = false): string {
   // usage
   line = line.replace(tscUsageSyntaxRegex, (m) => `\u001B[33m${m}\u001B[39m`); // Yellow
 
-  // file emitted
-  line = line.replace(
-    typescriptEmittedFileRegex,
-    (_0, stdPrefix, file) => `\u001B[30m\u001B[4m${stdPrefix}\u001B[0m \u001B[30m${file}\u001B[0m`,
-  ); // Grey underlined / Grey
-
   if (noClear && compilationStartedRegex.test(line)) {
     return '\n\n----------------------\n' + line;
   }

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -91,18 +91,14 @@ interface INodeSettings {
 }
 
 function spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles }: INodeSettings, args: string[]): ChildProcess {
-  const nodeArgs = [];
-  if (maxNodeMem) {
-    nodeArgs.push(`--max_old_space_size=${maxNodeMem}`);
-  }
-  if (signalEmittedFiles && !requestedToListEmittedFiles) {
-    nodeArgs.push(`--listEmittedFiles`);
-  }
-
   const tscBin = getTscPath();
-  nodeArgs.push(tscBin);
+  const nodeArgs = [
+    ...((maxNodeMem) ? [`--max_old_space_size=${maxNodeMem}`] : []),
+    tscBin,
+    ...((signalEmittedFiles || requestedToListEmittedFiles) ? ['--listEmittedFiles'] : []),
+    ...args
+  ];
 
-  nodeArgs.push(...args);
   return spawn('node', nodeArgs);
 }
 


### PR DESCRIPTION
Follow v6 pre release tries: https://github.com/gilamran/tsc-watch/discussions/145

Summary:
- regression: disable back TSFILE (emitted files log) useless styling
- major: fix `--listEmittedFiles` param in node tsc syscall
- improvement: enables to import `/client` instead of `dist/client`