### PR TITLE
Fix for #87

### DIFF
--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -7,15 +7,120 @@ const run = require('./runner');
 const { extractArgs } = require('./args-manager');
 const { manipulate, detectState, deleteClear, print } = require('./stdout-manipulator');
 const readline = require('readline');
-const CancellationToken = require('cancellationtoken').default;
+
+class Command
+{
+  killer = null;
+
+  constructor(command, signal)
+  {
+    this.command = command;
+    this.signal = signal;
+  }
+
+  run({ emitSignal })
+  {
+    const command = this.command();
+
+    if (command)
+    {
+      this.killer = run(this.command());
+    }
+
+    if (emitSignal)
+    {
+      Signal.send(this.signal);
+    }
+  }
+
+  kill()
+  {
+    const killer = this.killer;
+    this.killer = null;
+
+    if (killer)
+    {
+      return killer();
+    }
+
+    return Promise.resolve();
+  }
+}
+
+class CommandRunner
+{
+  commands = {
+    firstSuccess: new Command(() => onFirstSuccessCommand, 'first_success'),
+    success: new Command(() => onSuccessCommand, 'success'),
+    failure: new Command(() => onFailureCommand, 'compile_errors'),
+    compilationStarted: new Command(() => onCompilationStarted, 'started'),
+    compilationComplete: new Command(() => onCompilationComplete, 'complete'),
+  }
+
+  currentState = { state: 'not_running' };
+  desiredState = { state: 'not_running' };
+  nextRunID = 1;
+
+  run({ commands, isTriggeredByClient })
+  {
+    this.setDesiredState({ state: 'running', commands, isTriggeredByClient, runID: this.nextRunID++ });
+  }
+
+  async shutdown()
+  {
+    await this._kill();
+  }
+
+  setDesiredState(desiredState)
+  {
+    this.desiredState = desiredState;
+    this._stateMachine();
+  }
+
+  _stateMachine()
+  {
+    if (this.desiredState.state === 'running')
+    {
+      if (this.currentState.state === 'running' && this.currentState.runID !== this.desiredState.runID)
+      {
+        this._kill();
+      }
+      else if (this.currentState.state === 'not_running')
+      {
+        this._run(this.desiredState);
+      }
+    }
+    else if (this.desiredState.state === 'not_running')
+    {
+      if (this.currentState.state === 'running')
+      {
+        this._kill();
+      }
+    }
+  }
+
+  _run({ commands, isTriggeredByClient, runID })
+  {
+    this.currentState = { state: 'running', commands, isTriggeredByClient, runID };
+    for (const command of commands)
+    {
+      command.run({ emitSignal: true });
+    }
+    this._stateMachine();
+  }
+
+  async _kill()
+  {
+    this.currentState = { state: 'killing' };
+    await Promise.all(Object.values(this.commands).map(c => c.kill()));
+    this.currentState = { state: 'not_running' };
+    this._stateMachine();
+  }
+}
+
+const commandRunner = new CommandRunner();
 
 let firstTime = true;
-let firstSuccessKiller = null;
-let successKiller = null;
-let failureKiller = null;
-let compilationStartedKiller = null;
-let compilationCompleteKiller = null;
-let cancelKillProcesses = () => {};
 
 const {
   onFirstSuccessCommand,
@@ -30,64 +135,6 @@ const {
   compiler,
   args,
 } = extractArgs(process.argv);
-
-function silentlyHandleCancellation(error)
-{
-  if (error instanceof CancellationToken.CancellationError)
-  {
-
-  }
-  else
-  {
-    // Rethrow all other errors.
-    throw e;
-  }
-}
-
-function killProcesses(killAll) {
-  // Cancel any earlier invocation of this function that is still in progress.
-  cancelKillProcesses();
-  const { cancel, token } = CancellationToken.create();
-  cancelKillProcesses = cancel;
-
-  return token.racePromise(Promise.all([
-    killAll && firstSuccessKiller ? firstSuccessKiller() : null,
-    successKiller ? successKiller() : null,
-    failureKiller ? failureKiller() : null,
-    compilationStartedKiller ? compilationStartedKiller() : null,
-    compilationCompleteKiller ? compilationCompleteKiller() : null,
-  ]));
-}
-
-function runOnCompilationStarted() {
-  if (onCompilationStarted) {
-    compilationStartedKiller = run(onCompilationStarted);
-  }
-}
-
-function runOnCompilationComplete() {
-  if (onCompilationComplete) {
-    compilationCompleteKiller = run(onCompilationComplete);
-  }
-}
-
-function runOnFailureCommand() {
-  if (onFailureCommand) {
-    failureKiller = run(onFailureCommand);
-  }
-}
-
-function runOnFirstSuccessCommand() {
-  if (onFirstSuccessCommand) {
-    firstSuccessKiller = run(onFirstSuccessCommand);
-  }
-}
-
-function runOnSuccessCommand() {
-  if (onSuccessCommand) {
-    successKiller = run(onSuccessCommand);
-  }
-}
 
 function buildNodeParams(allArgs, { maxNodeMem }){
   let tscBin;
@@ -134,86 +181,80 @@ rl.on('line', function (input) {
     Signal.emitFile(state.fileEmitted);
   }
 
+  let commands = [];
+
   if (compilationStarted) {
-    killProcesses(false).then(() => {
-      runOnCompilationStarted();
-      Signal.emitStarted();
-    }).catch(silentlyHandleCancellation);
+    commands.push(commandRunner.commands.compilationStarted);
   }
 
   if (compilationComplete) {
-    killProcesses(false).then(() => {
-      runOnCompilationComplete();
+    commands.push(commandRunner.commands.compilationComplete);
 
-      if (compilationErrorSinceStart) {
-        Signal.emitFail();
-        runOnFailureCommand();
-      } else {
-        if (firstTime) {
-          firstTime = false;
-          Signal.emitFirstSuccess();
-          runOnFirstSuccessCommand();
-        }
-
-        Signal.emitSuccess();
-        runOnSuccessCommand();
+    if (compilationErrorSinceStart)
+    {
+      commands.push(commandRunner.commands.failure);
+    }
+    else
+    {
+      if (firstTime)
+      {
+        firstTime = false;
+        commands.push(commandRunner.commands.firstSuccess);
       }
-    }).catch(silentlyHandleCancellation);
+
+      commands.push(commandRunner.commands.success);
+    }
+  }
+
+  if (commands.length > 0)
+  {
+    commandRunner.run({ isTriggeredByClient: false, commands });
   }
 });
 
 if (typeof process.on === 'function') {
   process.on('message', (msg) => {
-    let promise;
-    let func;
+    let command = null;
     switch (msg) {
       case 'run-on-compilation-started-command':
-        promise = compilationStartedKiller ? compilationStartedKiller() : Promise.resolve();
-        func = runOnCompilationStarted;
+        command = commandRunner.commands.compilationStarted;
         break;
 
       case 'run-on-compilation-complete-command':
-        promise = compilationCompleteKiller ? compilationCompleteKiller() : Promise.resolve();
-        func = runOnCompilationComplete;
+        command = commandRunner.commands.compilationComplete;
         break;
 
       case 'run-on-first-success-command':
-        promise = firstSuccessKiller ? firstSuccessKiller() : Promise.resolve();
-        func = runOnFirstSuccessCommand;
+        command = commandRunner.commands.firstSuccess;
         break;
 
       case 'run-on-failure-command':
-        promise = failureKiller ? failureKiller() : Promise.resolve();
-        func = runOnFailureCommand;
+        command = commandRunner.commands.failure;
         break;
 
       case 'run-on-success-command':
-        promise = successKiller ? successKiller() : Promise.resolve();
-        func = runOnSuccessCommand;
+        command = commandRunner.commands.success;
         break;
 
       default:
         console.log('Unknown message', msg);
     }
 
-    if (func) {
-      promise.then(func);
+    if (command)
+    {
+      commandRunner.run({ commands: [command], isTriggeredByClient: true });
     }
   });
 }
 
 const Signal = {
   send: typeof process.send === 'function' ? (...e) => process.send(...e) : () => { },
-  emitStarted: () => Signal.send('started'),
-  emitFirstSuccess: () => Signal.send('first_success'),
-  emitSuccess: () => Signal.send('success'),
-  emitFail: () => Signal.send('compile_errors'),
   emitFile: (path) => Signal.send(`file_emitted:${path}`),
 };
 
 nodeCleanup((_exitCode, signal) => {
   tscProcess.kill(signal);
-  killProcesses(true).catch(silentlyHandleCancellation).finally(() => process.exit());
+  commandRunner.shutdown().finally(process.exit());
   // don't call cleanup handler again
   nodeCleanup.uninstall();
   return false;

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -8,16 +8,29 @@ const { extractArgs } = require('./args-manager');
 const { manipulate, detectState, deleteClear, print } = require('./stdout-manipulator');
 const readline = require('readline');
 
+/**
+ * Represents a command that can be executed in response to a compilation event.
+ * Used by CommandRunner to manage the lifecycle of the process that executes the command.
+ */
 class Command
 {
   killer = null;
 
+  /**
+   * @param {*} command A function returning the function that runs the command.
+   * @param {*} signal The name of the signal to emit when this command is run.
+   */
   constructor(command, signal)
   {
     this.command = command;
     this.signal = signal;
   }
 
+  /**
+   * Start running the command.
+   * This must not be called while the command is already running.
+   * @param {boolean} emitSignal If true, emit a signal to indicate that the command has been started.
+   */
   run({ emitSignal })
   {
     const command = this.command();
@@ -33,6 +46,10 @@ class Command
     }
   }
 
+  /**
+   * Kill the running command.
+   * @returns A Promise that resolves when the command has been killed.
+   */
   kill()
   {
     const killer = this.killer;
@@ -47,6 +64,11 @@ class Command
   }
 }
 
+/**
+ * Manages the process lifecycle of the various commands that run in response to compilation events.
+ * One or more commands can be run concurrently, e.g. if a single compilation results in multiple events.
+ * See the documentation for {CommandRunner.run()} for more information.
+ */
 class CommandRunner
 {
   commands = {
@@ -61,17 +83,34 @@ class CommandRunner
   desiredState = { state: 'not_running' };
   nextRunID = 1;
 
+  /**
+   * Start running the given set of commands.
+   * If commands are already running, these will be killed first. (Even if the already running commands are identical to the new ones.)
+   * @param {*} commands An array of `Command`s to run.
+   * @param {boolean} isTriggeredByClient If true, this event was triggered by the `tsc-watch` client API, rather than an actual compilation event. 
+   */
   run({ commands, isTriggeredByClient })
   {
-    this.setDesiredState({ state: 'running', commands, isTriggeredByClient, runID: this.nextRunID++ });
+    this._setDesiredState({ state: 'running', commands, isTriggeredByClient, runID: this.nextRunID++ });
   }
 
+  /**
+   * Kill all running commands in preparation for process shutdown.
+   */
   async shutdown()
   {
     await this._kill();
   }
 
-  setDesiredState(desiredState)
+  /**
+   * Set the desired state of the CommandRunner.
+   * This indicates which commands it should be running, if any.
+   * It is safe to call this at any time without worrying about the current state of the commands.
+   * @param {*} desiredState The new desired state.
+   * Note: `{ state: 'killing' }` is not a valid desired state - to kill a running process, set the desired
+   * state to `{ state: 'not_running' }`, and the state machine will transition to `not_running` via `killing`.
+   */
+  _setDesiredState(desiredState)
   {
     this.desiredState = desiredState;
     this._stateMachine();
@@ -83,10 +122,16 @@ class CommandRunner
     {
       if (this.currentState.state === 'running' && this.currentState.runID !== this.desiredState.runID)
       {
+        // running -> running
+        // We're already running some commands, and now we want to run some new ones.
+        // Need to kill the old commands first.
         this._kill();
       }
       else if (this.currentState.state === 'not_running')
       {
+        // not_running -> running
+        // We're not currently running anything, and we want to run some commands.
+        // We can go ahead and run them.
         this._run(this.desiredState);
       }
     }
@@ -94,11 +139,18 @@ class CommandRunner
     {
       if (this.currentState.state === 'running')
       {
+        // running -> not_running
+        // We're currently running commands, and we don't want to be.
+        // Need to kill the commands that are running.
         this._kill();
       }
     }
   }
 
+  /**
+   * Implements the transition from the `not_running` state to the `running` state.
+   * @param {*} state The data for the new state.
+   */
   _run({ commands, isTriggeredByClient, runID })
   {
     this.currentState = { state: 'running', commands, isTriggeredByClient, runID };
@@ -109,6 +161,10 @@ class CommandRunner
     this._stateMachine();
   }
 
+  /**
+   * Implements the transition from the `running` state to the `killing` state.
+   * Then, when killing is complete, transitions into the `not_running` state.
+   */
   async _kill()
   {
     this.currentState = { state: 'killing' };

--- a/lib/tsc-watch.js
+++ b/lib/tsc-watch.js
@@ -7,6 +7,7 @@ const run = require('./runner');
 const { extractArgs } = require('./args-manager');
 const { manipulate, detectState, deleteClear, print } = require('./stdout-manipulator');
 const readline = require('readline');
+const CancellationToken = require('cancellationtoken').default;
 
 let firstTime = true;
 let firstSuccessKiller = null;
@@ -14,6 +15,7 @@ let successKiller = null;
 let failureKiller = null;
 let compilationStartedKiller = null;
 let compilationCompleteKiller = null;
+let cancelKillProcesses = () => {};
 
 const {
   onFirstSuccessCommand,
@@ -29,14 +31,32 @@ const {
   args,
 } = extractArgs(process.argv);
 
+function silentlyHandleCancellation(error)
+{
+  if (error instanceof CancellationToken.CancellationError)
+  {
+
+  }
+  else
+  {
+    // Rethrow all other errors.
+    throw e;
+  }
+}
+
 function killProcesses(killAll) {
-  return Promise.all([
+  // Cancel any earlier invocation of this function that is still in progress.
+  cancelKillProcesses();
+  const { cancel, token } = CancellationToken.create();
+  cancelKillProcesses = cancel;
+
+  return token.racePromise(Promise.all([
     killAll && firstSuccessKiller ? firstSuccessKiller() : null,
     successKiller ? successKiller() : null,
     failureKiller ? failureKiller() : null,
     compilationStartedKiller ? compilationStartedKiller() : null,
     compilationCompleteKiller ? compilationCompleteKiller() : null,
-  ]);
+  ]));
 }
 
 function runOnCompilationStarted() {
@@ -118,7 +138,7 @@ rl.on('line', function (input) {
     killProcesses(false).then(() => {
       runOnCompilationStarted();
       Signal.emitStarted();
-    });
+    }).catch(silentlyHandleCancellation);
   }
 
   if (compilationComplete) {
@@ -138,7 +158,7 @@ rl.on('line', function (input) {
         Signal.emitSuccess();
         runOnSuccessCommand();
       }
-    });
+    }).catch(silentlyHandleCancellation);
   }
 });
 
@@ -193,7 +213,7 @@ const Signal = {
 
 nodeCleanup((_exitCode, signal) => {
   tscProcess.kill(signal);
-  killProcesses(true).then(() => process.exit());
+  killProcesses(true).catch(silentlyHandleCancellation).finally(() => process.exit());
   // don't call cleanup handler again
   nodeCleanup.uninstall();
   return false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "tsc-watch",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tsc-watch",
-      "version": "4.6.0",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
+        "cancellationtoken": "^2.2.0",
         "cross-spawn": "^7.0.3",
         "node-cleanup": "^2.1.2",
         "ps-tree": "^1.2.0",
@@ -20,6 +21,7 @@
       },
       "devDependencies": {
         "chai": "^4.3.4",
+        "find-process": "^1.4.7",
         "fs-extra": "^10.0.0",
         "mocha": "^9.1.3",
         "sinon": "^12.0.1",
@@ -188,6 +190,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cancellationtoken": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cancellationtoken/-/cancellationtoken-2.2.0.tgz",
+      "integrity": "sha512-uF4sHE5uh2VdEZtIRJKGoXAD9jm7bFY0tDRCzH4iLp262TOJ2lrtNHjMG2zc8H+GICOpELIpM7CGW5JeWnb3Hg=="
+    },
     "node_modules/chai": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
@@ -291,6 +298,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -423,6 +439,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-process": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+      "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "commander": "^5.1.0",
+        "debug": "^4.1.1"
+      },
+      "bin": {
+        "find-process": "bin/find-process.js"
       }
     },
     "node_modules/find-up": {
@@ -1438,6 +1468,11 @@
       "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
       "dev": true
     },
+    "cancellationtoken": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cancellationtoken/-/cancellationtoken-2.2.0.tgz",
+      "integrity": "sha512-uF4sHE5uh2VdEZtIRJKGoXAD9jm7bFY0tDRCzH4iLp262TOJ2lrtNHjMG2zc8H+GICOpELIpM7CGW5JeWnb3Hg=="
+    },
     "chai": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
@@ -1519,6 +1554,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true
     },
     "concat-map": {
@@ -1619,6 +1660,17 @@
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-process": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+      "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "commander": "^5.1.0",
+        "debug": "^4.1.1"
       }
     },
     "find-up": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "printWidth": 100
   },
   "dependencies": {
+    "cancellationtoken": "^2.2.0",
     "cross-spawn": "^7.0.3",
     "node-cleanup": "^2.1.2",
     "ps-tree": "^1.2.0",
@@ -43,6 +44,7 @@
   },
   "devDependencies": {
     "chai": "^4.3.4",
+    "find-process": "^1.4.7",
     "fs-extra": "^10.0.0",
     "mocha": "^9.1.3",
     "sinon": "^12.0.1",

--- a/test-commands/unkillable-command.js
+++ b/test-commands/unkillable-command.js
@@ -1,0 +1,5 @@
+process.on('SIGTERM', () => {
+    console.log('unkillable-command ignored SIGTERM');
+});
+console.log('unkillable-command started');
+process.stdin.resume(); // stop the process from exiting

--- a/test/driver.js
+++ b/test/driver.js
@@ -15,10 +15,15 @@ class Driver {
     return this;
   }
 
-  startWatch({ failFirst, pretty } = {}) {
+  startWatch({ failFirst, pretty, command } = {}) {
     const params = ['--noClear', '--out', './tmp/output.js', failFirst ? FAIL_FILE_PATH : SUCCESS_FILE_PATH];
     if (pretty) {
       params.push('--pretty');
+    }
+    if (command === 'unkillable-command')
+    {
+      params.push('--onSuccess');
+      params.push(`${process.execPath} ./test-commands/unkillable-command.js`);
     }
     this.proc = fork('./lib/tsc-watch.js', params, { stdio: 'inherit' });
 


### PR DESCRIPTION
This fixes #87 by adding a check that happens before running the commands for events such as  `onSuccess`. The check makes sure that there hasn't been another such event during the time delay between when the original event happened and when we were actually ready to start the new command. This situation can happen if the old command takes too long to respond our attempts to kill it.

I have also added a new test that fails without the change and passes with it. I wasn't sure which test suite to put it in, so let me know if you'd like me to move it to another test suite or create a new one for it. Also, the test uses a small script to simulate a process that doesn't respond nicely to `SIGTERM`, but I had to put that script outside the `test` directory (in `test-commands/unkillable-command.js`) to prevent it being picked up by the `test/**/*.js` glob and treated as a test suite.