### PR TITLE
Fix documentation regarding how to import/require TscWatchClient from 'tsc-watch/client'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,27 @@
 
 **Anything that you can do with `tsc` you can do with `tsc-watch`, the only difference is that `tsc-watch` can react to compilation status.**
 
-| Argument | Description |
-|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `--onSuccess COMMAND` | Executes `COMMAND` on **every successful** compilation. |
-| `--onFirstSuccess COMMAND` | Executes `COMMAND` on the **first successful** compilation. |
-| `--onFailure COMMAND` | Executes `COMMAND` on **every failed** compilation. |
-| `--onCompilationStarted COMMAND` | Executes `COMMAND` on **every compilation start** event (initial and incremental). |
-| `--onCompilationComplete COMMAND` | Executes `COMMAND` on **every successful or failed** compilation. |
-| `--maxNodeMem` | Calls `node` with a specific memory limit `max_old_space_size`, to use if your project needs more memory. |
-| `--noColors` | By default tsc-watch adds colors the output with green<br>on success, and in red on failure. <br>Add this argument to prevent that. |
-| `--noClear` | In watch mode the `tsc` compiler clears the screen before reporting<br>Add this argument to prevent that. |
-| `--signalEmittedFiles` | Will run `tsc` compiler with `--listEmittedFiles`, but hiding TSFILE lines. Use it to enable `file_emitted` event, while keeping tsc stdout silent. |
-| `--silent` | Do not print any messages on stdout. |
-| `--compiler PATH` | The `PATH` will be used instead of typescript compiler.<br>Default is `typescript/bin/tsc` |
+| Argument                          | Description                                                                                                                                         |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--onSuccess COMMAND`             | Executes `COMMAND` on **every successful** compilation.                                                                                             |
+| `--onFirstSuccess COMMAND`        | Executes `COMMAND` on the **first successful** compilation.                                                                                         |
+| `--onFailure COMMAND`             | Executes `COMMAND` on **every failed** compilation.                                                                                                 |
+| `--onCompilationStarted COMMAND`  | Executes `COMMAND` on **every compilation start** event (initial and incremental).                                                                  |
+| `--onCompilationComplete COMMAND` | Executes `COMMAND` on **every successful or failed** compilation.                                                                                   |
+| `--maxNodeMem`                    | Calls `node` with a specific memory limit `max_old_space_size`, to use if your project needs more memory.                                           |
+| `--noColors`                      | By default tsc-watch adds colors the output with green<br>on success, and in red on failure. <br>Add this argument to prevent that.                 |
+| `--noClear`                       | In watch mode the `tsc` compiler clears the screen before reporting<br>Add this argument to prevent that.                                           |
+| `--signalEmittedFiles`            | Will run `tsc` compiler with `--listEmittedFiles`, but hiding TSFILE lines. Use it to enable `file_emitted` event, while keeping tsc stdout silent. |
+| `--silent`                        | Do not print any messages on stdout.                                                                                                                |
+| `--compiler PATH`                 | The `PATH` will be used instead of typescript compiler.<br>Default is `typescript/bin/tsc`                                                          |
 
 Notes:
 
-* That all the above `COMMAND`s will be killed on process exit. (Using `SIGTERM`)
-  
-* A `COMMAND` is a single command and not multi command like `script1.sh && script2.sh`
-  
-* Any child process (`COMMAND`) will be terminated before creating a new one.
+- That all the above `COMMAND`s will be killed on process exit. (Using `SIGTERM`)
+
+- A `COMMAND` is a single command and not multi command like `script1.sh && script2.sh`
+
+- Any child process (`COMMAND`) will be terminated before creating a new one.
 
 ## Install
 
@@ -59,6 +59,7 @@ tsc-watch --onSuccess "node ./dist/server.js" --compiler my-typescript/bin/tsc
 ```
 
 ### From npm script
+
 ```
 "dev-server": "tsc-watch --noClear -p ./src/tsconfig.json --onSuccess \"node ./dist/server.js\"",
 ```
@@ -82,7 +83,11 @@ To kill the client, run `watch.kill()`
 Example usage:
 
 ```javascript
-const TscWatchClient = require('tsc-watch/client');
+// Using CommonJS:
+const { TscWatchClient } = require('tsc-watch/client');
+// Using ES6 import:
+import { TscWatchClient } from 'tsc-watch/client';
+
 const watch = new TscWatchClient();
 
 watch.on('started', () => {

--- a/tsc-watch-client-example.js
+++ b/tsc-watch-client-example.js
@@ -1,5 +1,6 @@
 const readline = require('readline');
-const TscWatchClient = require('./client');
+const { TscWatchClient } = require('./client');
+
 const client = new TscWatchClient();
 
 client.on('started', () => {


### PR DESCRIPTION
Fixes #156

`export default` is very discouraged in ES6 world:
- https://rajeshnaroth.medium.com/avoid-es6-default-exports-a24142978a7a
- https://blog.piotrnalepa.pl/2020/06/26/default-exports-vs-named-exports/
- https://www.reddit.com/r/javascript/comments/9amkc6/export_default_considered_harmful/

In fact while trying to do it I've faced typical problems because there is some ugly trick to be done for `export default` to not export an Object with a `default` field into it and so on. So in this PR I just fix the documentation in README and in the example script. IMHO this is better since:
- If we change the way `TscWatchClient` must be imported it would mean a compability breaking change.
- `tsc-watch` changed this in 6.0.0 version, which is a mayor update so it's ok to break backwards compatibility. But breaking it again in 6.0.1 is not that good.
- As stated above, dealing with `default export` in ES6 may lead to many problems that we can just avoid by not changing it.

NOTE: Those formatting changes in README are due my text editor. Hope they are not a problem.