### PR TITLE
fix: error TS6369: Option '--build' must be the first command line argument.

### DIFF
--- a/src/lib/args-manager.ts
+++ b/src/lib/args-manager.ts
@@ -64,6 +64,7 @@ export function extractArgs(inputArgs: string[]) {
   }
   if (signalEmittedFiles || requestedToListEmittedFiles) {
     if (args[0] === '--build' || args[0] === '-b') {
+      // TS6369: Option '--build' must be the first command line argument.
       args.splice(1, 0, '--listEmittedFiles');
     } else {
       args.unshift('--listEmittedFiles');

--- a/src/lib/args-manager.ts
+++ b/src/lib/args-manager.ts
@@ -56,12 +56,18 @@ export function extractArgs(inputArgs: string[]) {
   const silent = extractCommand(args, '--silent');
   const signalEmittedFiles = extractCommand(args, '--signalEmittedFiles');
   const requestedToListEmittedFiles = extractCommand(args, '--listEmittedFiles');
-  const buildMode = extractCommand(args, '--build') || extractCommand(args, '--b');
   let compiler = extractCommandWithValue(args, '--compiler');
   if (!compiler) {
     compiler = 'typescript/bin/tsc';
   } else {
     compiler = require.resolve(compiler, { paths: [process.cwd()] });
+  }
+  if (signalEmittedFiles || requestedToListEmittedFiles) {
+    if (args[0] === '--build' || args[0] === '-b') {
+      args.splice(1, 0, '--listEmittedFiles');
+    } else {
+      args.unshift('--listEmittedFiles');
+    }
   }
 
   return {
@@ -76,7 +82,6 @@ export function extractArgs(inputArgs: string[]) {
     requestedToListEmittedFiles,
     signalEmittedFiles,
     silent,
-    buildMode,
     compiler,
     args,
   };

--- a/src/lib/args-manager.ts
+++ b/src/lib/args-manager.ts
@@ -56,6 +56,7 @@ export function extractArgs(inputArgs: string[]) {
   const silent = extractCommand(args, '--silent');
   const signalEmittedFiles = extractCommand(args, '--signalEmittedFiles');
   const requestedToListEmittedFiles = extractCommand(args, '--listEmittedFiles');
+  const buildMode = extractCommand(args, '--build') || extractCommand(args, '--b');
   let compiler = extractCommandWithValue(args, '--compiler');
   if (!compiler) {
     compiler = 'typescript/bin/tsc';
@@ -75,6 +76,7 @@ export function extractArgs(inputArgs: string[]) {
     requestedToListEmittedFiles,
     signalEmittedFiles,
     silent,
+    buildMode,
     compiler,
     args,
   };

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -27,7 +27,6 @@ const {
   requestedToListEmittedFiles,
   signalEmittedFiles,
   silent,
-  buildMode,
   compiler,
   args,
 } = extractArgs(process.argv);
@@ -119,16 +118,13 @@ interface INodeSettings {
   maxNodeMem: string | null;
   requestedToListEmittedFiles: boolean;
   signalEmittedFiles: boolean;
-  buildMode: boolean;
 }
 
-function spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles, buildMode }: INodeSettings, args: string[]): ChildProcess {
+function spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles }: INodeSettings, args: string[]): ChildProcess {
   const tscBin = getTscPath();
   const nodeArgs = [
     ...((maxNodeMem) ? [`--max_old_space_size=${maxNodeMem}`] : []),
     tscBin,
-    ...(buildMode ? ['--build'] : []),
-    ...((signalEmittedFiles || requestedToListEmittedFiles) ? ['--listEmittedFiles'] : []),
     ...args
   ];
 
@@ -142,7 +138,7 @@ function echoExit(code: number | null, signal: string | null) {
 }
 
 let compilationErrorSinceStart = false;
-const tscProcess = spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles, buildMode }, args);
+const tscProcess = spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles }, args);
 if (!tscProcess.stdout) {
   throw new Error('Unable to read Typescript stdout');
 }

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -27,6 +27,7 @@ const {
   requestedToListEmittedFiles,
   signalEmittedFiles,
   silent,
+  buildMode,
   compiler,
   args,
 } = extractArgs(process.argv);
@@ -118,13 +119,15 @@ interface INodeSettings {
   maxNodeMem: string | null;
   requestedToListEmittedFiles: boolean;
   signalEmittedFiles: boolean;
+  buildMode: boolean;
 }
 
-function spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles }: INodeSettings, args: string[]): ChildProcess {
+function spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles, buildMode }: INodeSettings, args: string[]): ChildProcess {
   const tscBin = getTscPath();
   const nodeArgs = [
     ...((maxNodeMem) ? [`--max_old_space_size=${maxNodeMem}`] : []),
     tscBin,
+    ...(buildMode ? ['--build'] : []),
     ...((signalEmittedFiles || requestedToListEmittedFiles) ? ['--listEmittedFiles'] : []),
     ...args
   ];
@@ -139,7 +142,7 @@ function echoExit(code: number | null, signal: string | null) {
 }
 
 let compilationErrorSinceStart = false;
-const tscProcess = spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles }, args);
+const tscProcess = spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles, buildMode }, args);
 if (!tscProcess.stdout) {
   throw new Error('Unable to read Typescript stdout');
 }

--- a/src/test/args-manager.test.ts
+++ b/src/test/args-manager.test.ts
@@ -43,6 +43,19 @@ describe('Args Manager', () => {
     expect(args.indexOf('--watch')).toBe(3);
   });
 
+  it('Should not insert args before --build (TS6369)', () => {
+    const { args } = extractArgs([
+      'node',
+      'tsc-watch.js',
+      '--signalEmittedFiles',
+      '--build',
+      '1.tsconfig.conf',
+      '2.tsconfig.conf',
+    ]);
+    expect(args.indexOf('--build')).toBe(0);
+    expect(args.indexOf('--listEmittedFiles')).toBe(1);
+  })
+
   it('Should not re-add watch', () => {
     expect(
       extractArgs(['node', 'tsc-watch.js', '-w', '1.ts']).args.indexOf('-w'),
@@ -118,11 +131,13 @@ describe('Args Manager', () => {
   it('Should return the signalEmittedFiles', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).signalEmittedFiles).toBe(false);
     expect(extractArgs(['node', 'tsc-watch.js', '--signalEmittedFiles', '1.ts']).signalEmittedFiles).toBe(true);
+    expect(extractArgs(['node', 'tsc-watch.js', '--signalEmittedFiles', '1.ts']).args.includes('--listEmittedFiles')).toBe(true);
   });
 
   it('Should return requestedToListEmittedFiles when tsc native listEmittedFiles is set', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).requestedToListEmittedFiles).toBe(false);
     expect(extractArgs(['node', 'tsc-watch.js', '--listEmittedFiles', '1.ts']).requestedToListEmittedFiles).toBe(true);
+    expect(extractArgs(['node', 'tsc-watch.js', '--listEmittedFiles', '1.ts']).args.includes('--listEmittedFiles')).toBe(true);
   });
 
   it('Should return the compiler', () => {


### PR DESCRIPTION
Problem
---
When we use `--signalEmittedFiles` it will insert `--listEmittedFiles` and then `tsc` will complain

> Option '--build' must be the first command line argument.

Solution
---
Extract `-b`/`--build` and move it before `--listEmittedFiles`.