### PR TITLE
feat: --onEmit

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -58,6 +58,12 @@ export class TscWatchClient extends EventEmitter {
       this.tsc.send('run-on-success-command');
     }
   }
+
+  runOnEmitCommand() {
+    if (this.tsc) {
+      this.tsc.send('run-on-emit-command');
+    }
+  }
 }
 
 function deserializeTscMessage(strMsg: string): [string, string?] {

--- a/src/lib/args-manager.ts
+++ b/src/lib/args-manager.ts
@@ -48,6 +48,8 @@ export function extractArgs(inputArgs: string[]) {
   const onFirstSuccessCommand = extractCommandWithValue(args, '--onFirstSuccess');
   const onSuccessCommand = extractCommandWithValue(args, '--onSuccess');
   const onFailureCommand = extractCommandWithValue(args, '--onFailure');
+  const onEmitCommand = extractCommandWithValue(args, '--onEmit');
+  const onEmitDebounce = Number(extractCommandWithValue(args, '--onEmitDebounce')) || 300;
   const onCompilationStarted = extractCommandWithValue(args, '--onCompilationStarted');
   const onCompilationComplete = extractCommandWithValue(args, '--onCompilationComplete');
   const maxNodeMem = extractCommandWithValue(args, '--maxNodeMem');
@@ -67,6 +69,8 @@ export function extractArgs(inputArgs: string[]) {
     onFirstSuccessCommand,
     onSuccessCommand,
     onFailureCommand,
+    onEmitCommand,
+    onEmitDebounce,
     onCompilationStarted,
     onCompilationComplete,
     maxNodeMem,


### PR DESCRIPTION
We needed this to avoid an infinite loop, maybe it will be useful for others.

Problem
---
If the `onSuccess` COMMAND touches any source file (e.g. generate GraphQL types), then there will be an infinite loop.

Solution
---
TypeScript does not emit for unchanged source files, so `onEmit` will not infinite loop. It also has added benefits:
- less noisy on success
- if `tsconfig.json` is configured to emit on error, user's app will still update with type errors