### PR TITLE
build: run build in prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The TypeScript compiler with onSuccess command",
   "scripts": {
     "clean": "rimraf dist && rimraf tmp",
-    "prepublish": "crlf --set=LF index.js client.js dist/**/*",
+    "prepublishOnly": "npm run build && crlf --set=LF index.js client.js dist/**/*",
     "test": "npm run build && jest --verbose --runInBand",
     "build": "npm run clean && npm run build-lib && npm run build-client",
     "build-lib": "tsc -p tsconfig.json",


### PR DESCRIPTION
- needs `npm run build` since the latest npm code doesn't have the latest changes: https://www.npmjs.com/package/tsc-watch?activeTab=code
- `prepublish` got deprecated in npm 5 (2017) for `prepublishOnly`: https://docs.npmjs.com/cli/v6/using-npm/scripts