### PR TITLE
bugfix/issue-154: detect when --watch or -w is already provided in tsc-watch command line, even as the first parameter

### DIFF
--- a/src/lib/args-manager.ts
+++ b/src/lib/args-manager.ts
@@ -8,7 +8,7 @@ function getCommandIdx(args: string[], command: string): number {
 }
 
 export function isCommandExist(args: string[], command: string): boolean {
-  return getCommandIdx(args, command) > 0;
+  return getCommandIdx(args, command) >= 0;
 }
 
 export function hasWatchCommand(args: string[]): boolean {

--- a/src/test/args-manager.test.ts
+++ b/src/test/args-manager.test.ts
@@ -65,9 +65,6 @@ describe('Args Manager', () => {
       extractArgs(['node', 'tsc-watch.js', '--watch', '1.ts']).args.filter(isWatchParam).length
     ).toBe(1);
     expect(
-      extractArgs(['node', 'tsc-watch.js', '--watch', '1.ts']).args.filter(isWatchParam).length
-    ).toBe(-1);
-    expect(
       extractArgs(['node', 'tsc-watch.js', '1.ts']).args.filter(isWatchParam).length
     ).toBe(1);
   });

--- a/src/test/args-manager.test.ts
+++ b/src/test/args-manager.test.ts
@@ -57,15 +57,19 @@ describe('Args Manager', () => {
   })
 
   it('Should not re-add watch', () => {
+    const isWatchParam = (elt: string) => elt === '-w' || elt === '--watch';
     expect(
-      extractArgs(['node', 'tsc-watch.js', '-w', '1.ts']).args.indexOf('-w'),
-    ).toBeGreaterThan(-1);
+      extractArgs(['node', 'tsc-watch.js', '-w', '1.ts']).args.filter(isWatchParam).length
+    ).toBe(1);
     expect(
-      extractArgs(['node', 'tsc-watch.js', '--watch', '1.ts']).args.indexOf('--watch'),
-    ).toBeGreaterThan(-1);
+      extractArgs(['node', 'tsc-watch.js', '--watch', '1.ts']).args.filter(isWatchParam).length
+    ).toBe(1);
     expect(
-      extractArgs(['node', 'tsc-watch.js', '--watch', '1.ts']).args.indexOf('--watch'),
-    ).toBeGreaterThan(-1);
+      extractArgs(['node', 'tsc-watch.js', '--watch', '1.ts']).args.filter(isWatchParam).length
+    ).toBe(-1);
+    expect(
+      extractArgs(['node', 'tsc-watch.js', '1.ts']).args.filter(isWatchParam).length
+    ).toBe(1);
   });
 
   it('Should return the onFirstSuccessCommand', () => {


### PR DESCRIPTION
This PR addresses an off-by-one issue in `isCommandExist(args, command)` within args-manager.ts (as noted in [issue #154](https://github.com/gilamran/tsc-watch/issues/154#issuecomment-2888568618)) that causes tsc-watch not to detect when `--watch` is provided as the very first parameter on the tsc-watch command line.

Assertions within the associated unit test have also been "tightened" to properly detect this (now resolved) error.

Note that with this change the `--no-watch` capability requested in issue #154 is now reliably available by passing `--watch false` on the `tsc-watch` command line. (To be clear, as noted in the issue discussion thread, this capability was already _generally_ available, but due to the bug addressed by this PR it would not work when `--watch` was the very first parameter in the tsc-watch command line)