### PR TITLE
Feat/prefer local tsc

### DIFF
--- a/src/lib/args-manager.ts
+++ b/src/lib/args-manager.ts
@@ -61,8 +61,6 @@ export function extractArgs(inputArgs: string[]) {
   let compiler = extractCommandWithValue(args, '--compiler');
   if (!compiler) {
     compiler = 'typescript/bin/tsc';
-  } else {
-    compiler = require.resolve(compiler, { paths: [process.cwd()] });
   }
   if (signalEmittedFiles || requestedToListEmittedFiles) {
     if (args[0] === '--build' || args[0] === '-b') {

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -8,7 +8,6 @@ import { debounce } from './debounce';
 import { manipulate, detectState, deleteClear, print } from './stdout-manipulator';
 import { createInterface } from 'readline';
 import { ChildProcess } from 'child_process';
-import { sep } from 'path';
 
 let firstTime = true;
 let firstSuccessKiller: (() => Promise<void>) | null = null;
@@ -140,13 +139,7 @@ function getTscPath(): string {
 
   // try to require local tsc
   try {
-    const resolvePaths = [];
-    const paths = process.cwd().split(sep);
-    for (let i = paths.length; i > 0; i--) {
-      const resolvePath = [...paths.slice(0, i), 'node_modules'].join(sep);
-      resolvePaths.push(resolvePath);
-    }
-    return require.resolve(compiler, { paths: resolvePaths });
+    return require.resolve(compiler, { paths: [process.cwd()] });
   } catch (e) {
     console.log('require local tsc failed, try to use global tsc');
   }

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -142,8 +142,8 @@ function getTscPath(): string {
   try {
     const resolvePaths = [];
     const paths = process.cwd().split(sep);
-    for (let i = 0; i < paths.length; i++) {
-      const resolvePath = [...paths.slice(0, i + 1), 'node_modules'].join(sep);
+    for (let i = paths.length; i > 0; i--) {
+      const resolvePath = [...paths.slice(0, i), 'node_modules'].join(sep);
       resolvePaths.push(resolvePath);
     }
     return require.resolve(compiler, { paths: resolvePaths });

--- a/src/lib/tsc-watch.ts
+++ b/src/lib/tsc-watch.ts
@@ -176,6 +176,7 @@ function spawnTsc({ maxNodeMem, requestedToListEmittedFiles, signalEmittedFiles 
     tscBin,
     ...args
   ];
+
   return spawn('node', nodeArgs);
 }
 

--- a/src/test/args-manager.test.ts
+++ b/src/test/args-manager.test.ts
@@ -160,6 +160,6 @@ describe('Args Manager', () => {
     expect(extractArgs(['node', 'tsc-watch.js', '1.ts']).compiler).toBe('typescript/bin/tsc');
     expect(
       extractArgs(['node', 'tsc-watch.js', '--compiler', 'typescript/lib/tsc', '1.ts']).compiler,
-    ).toBe(require.resolve('typescript/lib/tsc'));
+    ).toBe('typescript/lib/tsc');
   });
 });

--- a/src/test/client.test.ts
+++ b/src/test/client.test.ts
@@ -1,3 +1,4 @@
+import { arch, platform } from 'os';
 import { join } from 'path';
 import { TscWatchClient } from '../client';
 import {
@@ -85,7 +86,8 @@ describe('Client Events', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 1000));
       await waitFor(() => callback.mock.calls.length > 0);
-      expect(callback.mock.calls[0]).toEqual([1, null]);
+      const expectedResult = platform() === 'darwin' && arch() === 'arm64' ? [null, 'SIGKILL'] : [1, null];
+      expect(callback.mock.calls[0]).toEqual(expectedResult);
     });
   });
 });

--- a/src/test/client.test.ts
+++ b/src/test/client.test.ts
@@ -39,25 +39,25 @@ describe('Client Events', () => {
   describe('Events', () => {
     it('Should emit "started" on compilation start', () => {
       watchClient.on('started', callback);
-      watchClient.start('--noClear', '--out', OUTPUT_FILE, FAILING_FILE);
+      watchClient.start('--noClear', '--outFile', OUTPUT_FILE, FAILING_FILE);
       return waitFor(() => callback.mock.calls.length > 0);
     });
 
     it('Should emit "first_success" on first success', async () => {
       watchClient.on('first_success', callback);
-      watchClient.start('--noClear', '--out', OUTPUT_FILE, PASSING_FILE);
+      watchClient.start('--noClear', '--outFile', OUTPUT_FILE, PASSING_FILE);
       return waitFor(() => callback.mock.calls.length > 0);
     });
 
     it('Should emit "success" on first success', async () => {
       watchClient.on('success', callback);
-      watchClient.start('--noClear', '--out', OUTPUT_FILE, PASSING_FILE);
+      watchClient.start('--noClear', '--outFile', OUTPUT_FILE, PASSING_FILE);
       return waitFor(() => callback.mock.calls.length > 0);
     });
 
     it('Should deserialize and emit a "file_emitted" with the emitted file path', async function () {
       watchClient.on('file_emitted', callback);
-      watchClient.start('--noClear', '--listEmittedFiles', '--out', OUTPUT_FILE, PASSING_FILE);
+      watchClient.start('--noClear', '--listEmittedFiles', '--outFile', OUTPUT_FILE, PASSING_FILE);
       return waitFor(() => {
         if (callback.mock.calls.length > 0) {
           const firstCall = callback.mock.calls[0];
@@ -69,14 +69,14 @@ describe('Client Events', () => {
 
     it('Should fire "compile_errors" on when tsc compile errors occur', async () => {
       watchClient.on('compile_errors', callback);
-      watchClient.start('--noClear', '--out', OUTPUT_FILE, FAILING_FILE);
+      watchClient.start('--noClear', '--outFile', OUTPUT_FILE, FAILING_FILE);
       return waitFor(() => callback.mock.calls.length > 0);
     });
 
     it('Should fire back "exit" event when the process is exited by a signal', async function () {
       const forkSpy = jest.spyOn(child_process, 'fork');
       watchClient.on('exit', callback);
-      watchClient.start('--noClear', '--out', OUTPUT_FILE, PASSING_FILE);
+      watchClient.start('--noClear', '--outFile', OUTPUT_FILE, PASSING_FILE);
       const tscProcess: ChildProcess = forkSpy.mock.results[0].value;
 
       // Wait tsc-watch to be started and bound before to kill process

--- a/src/test/driver.ts
+++ b/src/test/driver.ts
@@ -23,7 +23,7 @@ export class Driver {
   public startWatch({ failFirst, pretty }: { failFirst?: boolean; pretty?: boolean } = {}): this {
     const params = [
       '--noClear',
-      '--out',
+      '--outFile',
       OUTPUT_FILE,
       failFirst ? FAILING_FILE : PASSING_FILE,
     ];

--- a/src/test/fixtures/tsc
+++ b/src/test/fixtures/tsc
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('mock tsc');

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -22,6 +22,7 @@ export const waitFor = (action: Function, timeout = 30000) => {
   });
 };
 
+export const FIXTURES_DIR = join(process.cwd(), 'src', 'test', 'fixtures');
 export const TMP_DIR = join(process.cwd(), 'tmp');
 export const TMP_FIXTURES_DIR = join(TMP_DIR, 'fixtures');
 export const OUTPUT_FILE = join(TMP_FIXTURES_DIR, 'output.js');
@@ -29,9 +30,19 @@ export const FAILING_FILE = join(TMP_FIXTURES_DIR, 'failing.ts');
 export const PASSING_FILE = join(TMP_FIXTURES_DIR, 'passing.ts');
 
 export function copyFixtures() {
-  fsExtra.copySync(join(process.cwd(), 'src', 'test', 'fixtures'), TMP_FIXTURES_DIR);
+  fsExtra.copySync(FIXTURES_DIR, TMP_FIXTURES_DIR);
 }
 
 export function removeFixtures() {
   fsExtra.removeSync(TMP_DIR);
+}
+
+export function copyFakeProjectHasTsc() {
+  const targetDir = join(TMP_DIR, 'fake-project-has-tsc', 'node_modules', 'typescript', 'bin', 'tsc');
+  fsExtra.copySync(join(FIXTURES_DIR, 'tsc'), targetDir);
+}
+
+export function copyFakeProjectNoTsc() {
+  const targetDir = join(TMP_DIR, 'fake-project-no-tsc');
+  fsExtra.ensureDirSync(targetDir);
 }


### PR DESCRIPTION
Add a logic before resolving tsc, according to [resolve API of nodejs](https://nodejs.org/docs/latest-v20.x/api/modules.html#requireresolverequest-options), we create the paths based on cwd.
The paths is:
```js
require.resolve('tsc',   {
  paths: [
    `${cwd}/project-root/node_modules`,
    `${cwd}/node_modules`,
    '/node_modules',
  ]
});
```
Then it will fallback to the original require logic if this require fails.

Other changes:
* Update existing test code to pass the new version of typescript
* Update existing test code to work in Mac OS(M1 chip)
* Add test for new logic